### PR TITLE
Registry hygiene + browser error-envelope normalization

### DIFF
--- a/plugins/osaurus.images.json
+++ b/plugins/osaurus.images.json
@@ -1,6 +1,6 @@
 {
   "plugin_id": "osaurus.images",
-  "name": "Osaurus Images",
+  "name": "Images",
   "description": "Image manipulation, conversion, and optimization tools",
   "homepage": "https://github.com/osaurus-ai/osaurus-images",
   "license": "MIT",

--- a/plugins/osaurus.mail.json
+++ b/plugins/osaurus.mail.json
@@ -1,6 +1,6 @@
 {
   "plugin_id": "osaurus.mail",
-  "name": "Osaurus Mail",
+  "name": "Mail",
   "description": "Read, search, compose, and manage Apple Mail — locally and privately",
   "homepage": "https://github.com/osaurus-ai/osaurus-mail",
   "license": "MIT",

--- a/plugins/osaurus.pptx.json
+++ b/plugins/osaurus.pptx.json
@@ -1,6 +1,6 @@
 {
   "plugin_id": "osaurus.pptx",
-  "name": "Osaurus PPTX",
+  "name": "PPTX",
   "description": "Create, modify, and export PowerPoint presentations. Supports text, images, shapes, tables, charts, themes, and more.",
   "homepage": "https://github.com/osaurus-ai/osaurus-pptx",
   "license": "MIT",

--- a/plugins/osaurus.telegram.json
+++ b/plugins/osaurus.telegram.json
@@ -84,70 +84,6 @@
       ]
     },
     {
-      "version": "1.0.10",
-      "release_date": "2026-03-03",
-      "artifacts": [
-        {
-          "os": "macos",
-          "arch": "arm64",
-          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.10/osaurus.telegram-1.0.10-macos-arm64.zip",
-          "sha256": "0c46a452de59517498e440dc447fad051fc4952448810dc30dc446f98764567c",
-          "min_macos": "15.0",
-          "minisign": {
-            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6Vib7h54JS6DYZRVEXK6w1yVBvxjlJxU1Cn8NSY4GilNh1nJLhIjJHcYAmC+oooEYhBPW5zXR1aAUH6zYwznKi7AQ=\ntrusted comment: timestamp:1772567173\tfile:osaurus.telegram-1.0.10-macos-arm64.zip\nz7kSYB4o0e8B1SXuNnPitG7LVaKeVskWY9KnM2iWZzCukWZh+QQNNKC0YIBIi+W7MY8KuYFO42xIa1Yp8pSvDg=="
-          }
-        }
-      ]
-    },
-    {
-      "version": "1.0.11",
-      "release_date": "2026-03-05",
-      "artifacts": [
-        {
-          "os": "macos",
-          "arch": "arm64",
-          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.11/osaurus.telegram-1.0.11-macos-arm64.zip",
-          "sha256": "603976100cd558e08d5e5ae32a63f6b760ae52bf67f710710807a8ade80ffa50",
-          "min_macos": "15.0",
-          "minisign": {
-            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6VibKFAQAIJa+Ic5VqQgZL0ymW1bBFMa6qgc4X+cQcYkkXzymVmd4s1JLAtDFPFWxWPVqMCOEqjByBtr/e1ItPQAg=\ntrusted comment: timestamp:1772734269\tfile:osaurus.telegram-1.0.11-macos-arm64.zip\ngjEUKf/Gle2d9Tr3jLEFyN3hsJG3vfGHqD3msrR/g86qz6FXbLfEG/rVoqVBouWYTEebJy+hx85VpkwTb4u7CA=="
-          }
-        }
-      ]
-    },
-    {
-      "version": "1.0.12",
-      "release_date": "2026-03-19",
-      "artifacts": [
-        {
-          "os": "macos",
-          "arch": "arm64",
-          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.12/osaurus.telegram-1.0.12-macos-arm64.zip",
-          "sha256": "07998ec745ef39e566457743138a251f1814b738e8a7166b58a6ab83917c1b99",
-          "min_macos": "15.0",
-          "minisign": {
-            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6Vif0gpP77Z8/VtipZ8CHsxLHiRuSjTsElJf2R5d7n00jZsC7AJA1/MVULDYFegDxud00oOvXZb7fOy6bxecTzUQw=\ntrusted comment: timestamp:1773927780\tfile:osaurus.telegram-1.0.12-macos-arm64.zip\nQHq+/r2N3bobwYMbZxSn0viS9EdcKPcMRxwmTciFKuJoexpSnpb7mqG7V0Sw6v6IdgHeKPWlvfc+ChDCGDeeAQ=="
-          }
-        }
-      ]
-    },
-    {
-      "version": "1.0.13",
-      "release_date": "2026-03-24",
-      "artifacts": [
-        {
-          "os": "macos",
-          "arch": "arm64",
-          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.13/osaurus.telegram-1.0.13-macos-arm64.zip",
-          "sha256": "222d1aea10e8ac891d2420c6c7cc06e5be8c1ab75a498d5764e27e01da6d605e",
-          "min_macos": "15.0",
-          "minisign": {
-            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6ViUB7XnsbDl+SJx3/6HGQ9WFT+enr6tMNnkGtU9KFIW/1miJ3vjLn23j0qpFodNOHfjPCGBXvHHzcqRx0ufRIKwE=\ntrusted comment: timestamp:1774368943\tfile:osaurus.telegram-1.0.13-macos-arm64.zip\nfs8lmJoD/HBsMpxhOkaHQGC0JGEZAxk2YQWXTQ1hCNzTerfj2bw3rnDGrV355ilHfYP305/lfZQ5xOs34RESAQ=="
-          }
-        }
-      ]
-    },
-    {
       "version": "1.0.2",
       "release_date": "2026-03-03",
       "artifacts": [
@@ -271,6 +207,70 @@
           "min_macos": "15.0",
           "minisign": {
             "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6VieANlXbgWowC3bpQOE6lJqKezmBd7DrfA6oqUo5ahac5sfxuvmnGVi95EfE5ssoiakdS1VSH/qvIGZdNCKnKBgU=\ntrusted comment: timestamp:1772563008\tfile:osaurus.telegram-1.0.9-macos-arm64.zip\n84lHWXy9GwOlZc2GqfHr76Ui1C/ZG71fM0AF8KkCPs0JkydVrMNEPuO97Nmw+Lwpf9B+P6WI7R7E9wbMR/poBA=="
+          }
+        }
+      ]
+    },
+    {
+      "version": "1.0.10",
+      "release_date": "2026-03-03",
+      "artifacts": [
+        {
+          "os": "macos",
+          "arch": "arm64",
+          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.10/osaurus.telegram-1.0.10-macos-arm64.zip",
+          "sha256": "0c46a452de59517498e440dc447fad051fc4952448810dc30dc446f98764567c",
+          "min_macos": "15.0",
+          "minisign": {
+            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6Vib7h54JS6DYZRVEXK6w1yVBvxjlJxU1Cn8NSY4GilNh1nJLhIjJHcYAmC+oooEYhBPW5zXR1aAUH6zYwznKi7AQ=\ntrusted comment: timestamp:1772567173\tfile:osaurus.telegram-1.0.10-macos-arm64.zip\nz7kSYB4o0e8B1SXuNnPitG7LVaKeVskWY9KnM2iWZzCukWZh+QQNNKC0YIBIi+W7MY8KuYFO42xIa1Yp8pSvDg=="
+          }
+        }
+      ]
+    },
+    {
+      "version": "1.0.11",
+      "release_date": "2026-03-05",
+      "artifacts": [
+        {
+          "os": "macos",
+          "arch": "arm64",
+          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.11/osaurus.telegram-1.0.11-macos-arm64.zip",
+          "sha256": "603976100cd558e08d5e5ae32a63f6b760ae52bf67f710710807a8ade80ffa50",
+          "min_macos": "15.0",
+          "minisign": {
+            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6VibKFAQAIJa+Ic5VqQgZL0ymW1bBFMa6qgc4X+cQcYkkXzymVmd4s1JLAtDFPFWxWPVqMCOEqjByBtr/e1ItPQAg=\ntrusted comment: timestamp:1772734269\tfile:osaurus.telegram-1.0.11-macos-arm64.zip\ngjEUKf/Gle2d9Tr3jLEFyN3hsJG3vfGHqD3msrR/g86qz6FXbLfEG/rVoqVBouWYTEebJy+hx85VpkwTb4u7CA=="
+          }
+        }
+      ]
+    },
+    {
+      "version": "1.0.12",
+      "release_date": "2026-03-19",
+      "artifacts": [
+        {
+          "os": "macos",
+          "arch": "arm64",
+          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.12/osaurus.telegram-1.0.12-macos-arm64.zip",
+          "sha256": "07998ec745ef39e566457743138a251f1814b738e8a7166b58a6ab83917c1b99",
+          "min_macos": "15.0",
+          "minisign": {
+            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6Vif0gpP77Z8/VtipZ8CHsxLHiRuSjTsElJf2R5d7n00jZsC7AJA1/MVULDYFegDxud00oOvXZb7fOy6bxecTzUQw=\ntrusted comment: timestamp:1773927780\tfile:osaurus.telegram-1.0.12-macos-arm64.zip\nQHq+/r2N3bobwYMbZxSn0viS9EdcKPcMRxwmTciFKuJoexpSnpb7mqG7V0Sw6v6IdgHeKPWlvfc+ChDCGDeeAQ=="
+          }
+        }
+      ]
+    },
+    {
+      "version": "1.0.13",
+      "release_date": "2026-03-24",
+      "artifacts": [
+        {
+          "os": "macos",
+          "arch": "arm64",
+          "url": "https://github.com/osaurus-ai/osaurus-telegram/releases/download/1.0.13/osaurus.telegram-1.0.13-macos-arm64.zip",
+          "sha256": "222d1aea10e8ac891d2420c6c7cc06e5be8c1ab75a498d5764e27e01da6d605e",
+          "min_macos": "15.0",
+          "minisign": {
+            "signature": "untrusted comment: signature from minisign secret key\nRWTmCafy0+6ViUB7XnsbDl+SJx3/6HGQ9WFT+enr6tMNnkGtU9KFIW/1miJ3vjLn23j0qpFodNOHfjPCGBXvHHzcqRx0ufRIKwE=\ntrusted comment: timestamp:1774368943\tfile:osaurus.telegram-1.0.13-macos-arm64.zip\nfs8lmJoD/HBsMpxhOkaHQGC0JGEZAxk2YQWXTQ1hCNzTerfj2bw3rnDGrV355ilHfYP305/lfZQ5xOs34RESAQ=="
           }
         }
       ]

--- a/plugins/osaurus.vision.json
+++ b/plugins/osaurus.vision.json
@@ -1,6 +1,6 @@
 {
   "plugin_id": "osaurus.vision",
-  "name": "Osaurus Vision",
+  "name": "Vision",
   "description": "macOS Vision framework integration for image analysis, text detection, face detection, background removal, and more",
   "homepage": "https://github.com/osaurus-ai/osaurus-vision",
   "license": "MIT",

--- a/plugins/osaurus.xlsx.json
+++ b/plugins/osaurus.xlsx.json
@@ -1,6 +1,6 @@
 {
   "plugin_id": "osaurus.xlsx",
-  "name": "Osaurus XLSX",
+  "name": "XLSX",
   "description": "Read, create, and modify Excel spreadsheet (.xlsx) files. Supports reading cell data, creating workbooks with multiple sheets, writing cells, formulas, CSV/TSV conversion, and batch modifications.",
   "homepage": "https://github.com/osaurus-ai/osaurus-xlsx",
   "license": "MIT",

--- a/tools/browser/CHANGELOG.md
+++ b/tools/browser/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **Tool errors are now reported to the host as failures.** Many tools returned bare `{"error": "..."}` objects or plain `"Error: ..."` strings. The Osaurus host classifies any result not shaped like `{"ok": false, ...}` as a SUCCESS, so those failures were silently surfaced to the model as successful calls. A single normalization boundary in `invoke` now rewrites such results into the canonical failure envelope (`{"ok": false, "kind": ..., "message": ..., "retryable": ...}`) while leaving real envelopes and success payloads untouched.
 - **`browser_reset_session` no longer crashes the host process.** Previously called `WKWebsiteDataStore.remove(forIdentifier:)` immediately after tearing down the `WKWebView`, which races with WebKit's Networking / Storage XPC processes that may still hold the per-identifier store open. On macOS 14+ the internal completion lambda inside `WebsiteDataStore::removeDataStoreWithIdentifierImpl` would dispatch to a NULL `RunLoop` and segfault inside the `com.apple.WebKit.WebsiteDataStoreIO` queue, taking the host (Osaurus) down with it. Reset now wipes every cookie / localStorage / IndexedDB / cache entry in place via the documented `removeData(ofTypes:modifiedSince:)` API and clears the persisted `profile_id` so the next session mints a brand-new isolated UUID. Behaviourally equivalent (next session is logged out and isolated) without the crash.
 
 ## 2.0.0

--- a/tools/browser/Sources/OsaurusBrowser/Plugin.swift
+++ b/tools/browser/Sources/OsaurusBrowser/Plugin.swift
@@ -1658,6 +1658,53 @@ func escapeJSON(_ s: String) -> String {
         .replacingOccurrences(of: "\t", with: "\\t")
 }
 
+/// Normalize a tool result so the Osaurus host can classify failures.
+///
+/// The host treats any output not shaped like `{"ok": false, ...}` as a
+/// SUCCESS. Several browser tools returned bare `{"error": "..."}` objects or
+/// plain `"Error: ..."` strings, which the host therefore reported to the model
+/// as successful calls. This rewrites those into the canonical failure envelope
+/// while leaving real envelopes (`ok: true` / `ok: false`) and ordinary success
+/// payloads untouched.
+func normalizeBrowserResult(_ result: String) -> String {
+    let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // Plain "Error: ..." string (not JSON).
+    if !trimmed.hasPrefix("{"),
+        trimmed.lowercased().hasPrefix("error:")
+    {
+        let msg = String(trimmed.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+        return
+            "{\"ok\":false,\"kind\":\"execution_error\",\"message\":\"\(escapeJSON(msg.isEmpty ? trimmed : msg))\",\"retryable\":true}"
+    }
+
+    // JSON object: leave anything that already carries an `ok` flag (canonical
+    // success or failure envelope) untouched; rewrite a bare `{"error": ...}`.
+    guard trimmed.hasPrefix("{"),
+        let data = trimmed.data(using: .utf8),
+        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        return result
+    }
+    if obj["ok"] != nil { return result }
+    guard let rawError = obj["error"] else { return result }
+
+    let message: String
+    if let s = rawError as? String {
+        message = s
+    } else if let d = rawError as? [String: Any], let m = d["message"] as? String {
+        message = m
+    } else {
+        message = "Tool error"
+    }
+    let kind =
+        message.localizedCaseInsensitiveContains("invalid argument")
+        || message.localizedCaseInsensitiveContains("required:")
+        ? "invalid_args" : "execution_error"
+    return
+        "{\"ok\":false,\"kind\":\"\(kind)\",\"message\":\"\(escapeJSON(message))\",\"retryable\":true}"
+}
+
 func toJSONString(_ value: Any?) -> String {
     guard let value = value else { return "null" }
 
@@ -3138,55 +3185,61 @@ private var api: osr_plugin_api = {
         let payload = String(cString: payloadPtr)
 
         guard type == "tool" else {
-            return makeCString("{\"error\": \"Unknown capability type\"}")
+            return makeCString(
+                normalizeBrowserResult("{\"error\": \"Unknown capability type\"}"))
         }
 
+        let result: String
         switch id {
         case "browser_navigate":
-            return makeCString(ctx.navigate(args: payload))
+            result = ctx.navigate(args: payload)
         case "browser_snapshot":
-            return makeCString(ctx.snapshot(args: payload))
+            result = ctx.snapshot(args: payload)
         case "browser_click":
-            return makeCString(ctx.click(args: payload))
+            result = ctx.click(args: payload)
         case "browser_type":
-            return makeCString(ctx.type(args: payload))
+            result = ctx.type(args: payload)
         case "browser_select":
-            return makeCString(ctx.select(args: payload))
+            result = ctx.select(args: payload)
         case "browser_hover":
-            return makeCString(ctx.hover(args: payload))
+            result = ctx.hover(args: payload)
         case "browser_scroll":
-            return makeCString(ctx.scroll(args: payload))
+            result = ctx.scroll(args: payload)
         case "browser_press_key":
-            return makeCString(ctx.pressKey(args: payload))
+            result = ctx.pressKey(args: payload)
         case "browser_wait_for":
-            return makeCString(ctx.waitFor(args: payload))
+            result = ctx.waitFor(args: payload)
         case "browser_screenshot":
-            return makeCString(ctx.screenshot(args: payload))
+            result = ctx.screenshot(args: payload)
         case "browser_execute_script":
-            return makeCString(ctx.executeScript(args: payload))
+            result = ctx.executeScript(args: payload)
         case "browser_do":
-            return makeCString(ctx.batchDo(args: payload))
+            result = ctx.batchDo(args: payload)
         case "browser_console_messages":
-            return makeCString(ctx.consoleMessages(args: payload))
+            result = ctx.consoleMessages(args: payload)
         case "browser_network_requests":
-            return makeCString(ctx.networkRequests(args: payload))
+            result = ctx.networkRequests(args: payload)
         case "browser_handle_dialog":
-            return makeCString(ctx.handleDialog(args: payload))
+            result = ctx.handleDialog(args: payload)
         case "browser_set_viewport":
-            return makeCString(ctx.setViewport(args: payload))
+            result = ctx.setViewport(args: payload)
         case "browser_set_user_agent":
-            return makeCString(ctx.setUserAgent(args: payload))
+            result = ctx.setUserAgent(args: payload)
         case "browser_cookies":
-            return makeCString(ctx.cookies(args: payload))
+            result = ctx.cookies(args: payload)
         case "browser_lock":
-            return makeCString(ctx.lock(args: payload))
+            result = ctx.lock(args: payload)
         case "browser_open_login":
-            return makeCString(ctx.openLogin(args: payload))
+            result = ctx.openLogin(args: payload)
         case "browser_reset_session":
-            return makeCString(ctx.resetSession(args: payload))
+            result = ctx.resetSession(args: payload)
         default:
-            return makeCString("{\"error\": \"Unknown tool: \(id)\"}")
+            result = "{\"error\": \"Unknown tool: \(id)\"}"
         }
+        // Single normalization boundary: rewrite bare {"error":...} / "Error:"
+        // results into the canonical failure envelope so the host classifies
+        // them as failures instead of auto-wrapping them as successes.
+        return makeCString(normalizeBrowserResult(result))
     }
 
     return api

--- a/tools/browser/Tests/OsaurusBrowserTests/NormalizeResultTests.swift
+++ b/tools/browser/Tests/OsaurusBrowserTests/NormalizeResultTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import OsaurusBrowser
+
+/// Tests for `normalizeBrowserResult`, the single dispatch-boundary that
+/// rewrites non-canonical tool errors into the Osaurus failure envelope.
+///
+/// The host treats any result that is not shaped like `{"ok": false, ...}` as a
+/// SUCCESS, so bare `{"error": ...}` objects and `"Error: ..."` strings were
+/// previously reported to the model as successful tool calls.
+final class NormalizeResultTests: XCTestCase {
+
+    private func parse(_ s: String) -> [String: Any]? {
+        guard let data = s.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    func test_bareErrorObjectBecomesFailureEnvelope() throws {
+        let out = normalizeBrowserResult("{\"error\": \"Invalid arguments. Required: url\"}")
+        let dict = try XCTUnwrap(parse(out))
+        XCTAssertEqual(dict["ok"] as? Bool, false)
+        XCTAssertEqual(dict["kind"] as? String, "invalid_args")
+        XCTAssertEqual(dict["retryable"] as? Bool, true)
+        XCTAssertEqual(dict["message"] as? String, "Invalid arguments. Required: url")
+    }
+
+    func test_nestedErrorObjectUsesItsMessage() throws {
+        let out = normalizeBrowserResult(
+            "{\"error\": {\"code\": \"X\", \"message\": \"boom happened\"}}")
+        let dict = try XCTUnwrap(parse(out))
+        XCTAssertEqual(dict["ok"] as? Bool, false)
+        XCTAssertEqual(dict["kind"] as? String, "execution_error")
+        XCTAssertEqual(dict["message"] as? String, "boom happened")
+    }
+
+    func test_plainErrorStringBecomesFailureEnvelope() throws {
+        let out = normalizeBrowserResult("Error: something went wrong")
+        let dict = try XCTUnwrap(parse(out))
+        XCTAssertEqual(dict["ok"] as? Bool, false)
+        XCTAssertEqual(dict["kind"] as? String, "execution_error")
+        XCTAssertEqual(dict["message"] as? String, "something went wrong")
+    }
+
+    func test_canonicalSuccessEnvelopeUntouched() {
+        let input = "{\"data\":{\"x\":1},\"ok\":true}"
+        XCTAssertEqual(normalizeBrowserResult(input), input)
+    }
+
+    func test_canonicalFailureEnvelopeUntouched() {
+        let input = "{\"error\":{\"code\":\"X\",\"message\":\"y\"},\"ok\":false}"
+        XCTAssertEqual(normalizeBrowserResult(input), input)
+    }
+
+    func test_plainSuccessTextUntouched() {
+        let input = "- heading\n  - button \"OK\""
+        XCTAssertEqual(normalizeBrowserResult(input), input)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the plugin audit: in-repo core tools + registry catalog hygiene.

- **Display-name normalization** — strip the legacy `Osaurus ` prefix so older plugins match the newer naming convention: `Osaurus Mail` → `Mail`, `Osaurus Images` → `Images`, `Osaurus PPTX` → `PPTX`, `Osaurus Vision` → `Vision`, `Osaurus XLSX` → `XLSX`. (Source-manifest renames land in each plugin repo's own PR so future catalog regenerations stay consistent.)
- **Telegram version ordering** — `osaurus.telegram` versions were string-sorted (`1.0.10` appeared between `1.0.1` and `1.0.2`); reordered by semantic version.
- **browser error envelopes** — many `browser_*` tools returned bare `{"error": "..."}` objects or `"Error: ..."` strings. The Osaurus host classifies any result not shaped like `{"ok": false, ...}` as a **success** (see `docs/TOOL_CONTRACT.md`), so those failures were reported to the model as successful calls. A single normalization boundary in `invoke` now rewrites them into the canonical failure envelope, leaving real envelopes and success payloads untouched. `fetch`/`search`/`time` already emit `{"ok": false, ...}`.

## Test plan

- [x] `python3 scripts/validate.py` passes
- [x] `python3 scripts/regenerate-catalogs.py --check` clean (no drift)
- [x] `swift build` (browser)
- [x] `swift test` (browser `NormalizeResultTests`, 6 passing)

Made with [Cursor](https://cursor.com)