### PR TITLE
Harden web tool URL policy adoption

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, main]
     paths:
       - "plugins/**"
+      - "Shared/**"
       - "scripts/validate.py"
   pull_request:
     branches: [master, main]
@@ -115,6 +116,9 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+
+      - name: Test shared web safety core
+        run: swift test --package-path Shared/OsaurusToolSecurity
 
       - name: Build all plugins
         run: |

--- a/Shared/OsaurusToolSecurity/Package.swift
+++ b/Shared/OsaurusToolSecurity/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "OsaurusToolSecurity",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(
+            name: "OsaurusToolSecurity",
+            type: .static,
+            targets: ["OsaurusToolSecurity"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "OsaurusToolSecurity",
+            path: "Sources/OsaurusToolSecurity"
+        ),
+        .testTarget(
+            name: "OsaurusToolSecurityTests",
+            dependencies: ["OsaurusToolSecurity"],
+            path: "Tests/OsaurusToolSecurityTests"
+        ),
+    ]
+)

--- a/Shared/OsaurusToolSecurity/README.md
+++ b/Shared/OsaurusToolSecurity/README.md
@@ -1,0 +1,93 @@
+# OsaurusToolSecurity
+
+Shared Swift security primitives for first-party web-capable tools. The package
+lives under `Shared/` instead of `tools/` so release scripts do not mistake it
+for a standalone plugin package. The library product is static, so later
+browser, fetch, and search adoption can compile the code into each plugin dylib
+without shipping an extra shared dynamic library.
+
+## Policy Contract
+
+`URLPolicy` is the canonical network URL gate for browser, fetch, and search
+adoption work.
+
+- `http` and `https` are the only network schemes accepted.
+- `about:blank` is accepted only when the caller opts in for browser flows that
+  explicitly need it.
+- URL userinfo is rejected with `SECRET_IN_URL`.
+- Unsafe schemes are rejected with `UNSAFE_SCHEME` before any private-network
+  allowance is considered.
+- Loopback, private, link-local, multicast, reserved, `.local`, and `.internal`
+  hosts are rejected by default with `SSRF_BLOCKED`.
+- Cloud metadata hostnames and metadata IPs are rejected even when
+  `allowPrivateNetwork` is enabled.
+- Host checks cover canonical IPv4, common non-dotted IPv4 forms, IPv6
+  loopback/link-local/ULA ranges, IPv4-mapped IPv6, the well-known NAT64
+  prefix, 6to4, and Teredo embedded IPv4 forms.
+- DNS results are checked through an injectable resolver. Tests use a stub
+  resolver; production callers use `SystemHostResolver`. Hostname resolution
+  fails closed when no addresses are available for validation.
+- `resolveHostnames` defaults to `true`. Disabling it is for deterministic
+  tests only; production network paths must leave DNS validation enabled or a
+  public-looking hostname can resolve to a private or metadata address after
+  policy approval.
+- Redirects must call `RedirectPolicy.evaluate(...)` for every hop. The helper
+  re-runs the full URL policy and strips sensitive headers across origins or
+  HTTPS-to-HTTP downgrades.
+
+Signed cloud URLs are valid request targets, so credential-looking query
+strings are redacted in output by default rather than automatically blocked.
+
+Stable URL policy error codes:
+
+- `SSRF_BLOCKED`
+- `SECRET_IN_URL`
+- `UNSAFE_SCHEME`
+
+## Redaction Contract
+
+`WebSafetyRedactor` provides:
+
+- URL userinfo and credential-query redaction.
+- Header redaction for `Authorization`, `Cookie`, `Set-Cookie`,
+  `Proxy-Authorization`, API key, token, secret, and credential-like headers.
+- Cookie value redaction that preserves non-secret attributes.
+- Text redaction for embedded credential URLs, auth header lines, bearer/basic
+  tokens, and common key/value secret pairs.
+
+Native plugins should redact their own outputs before returning tool results;
+they should not rely on a host-level scrubber.
+
+## Download Path Jail
+
+`DownloadPathValidator` resolves plain filenames under a caller-provided
+download or artifact directory. It rejects absolute paths, parent traversal,
+hidden names, tilde-prefixed names, path separators, and existing symlink
+targets that escape the base directory.
+
+## Residual DNS Risk
+
+The policy resolves and checks hostnames before allowing a request, fails closed
+when a hostname cannot be resolved for validation, and redirect targets must be
+re-validated. URLSession and WKWebView adoption cannot fully pin the vetted
+address to the eventual connection without deeper transport control, so DNS
+rebinding between validation and connection remains a known residual risk.
+Adoption PRs should document that risk unless the specific transport path can
+prove IP pinning. Adoption PRs should also re-check URL parsing against the
+transport they call, because URL parser differences can create the same kind of
+validate/connect gap.
+
+## Validation
+
+Run:
+
+```bash
+swift test --package-path Shared/OsaurusToolSecurity
+swift package describe --package-path Shared/OsaurusToolSecurity --type json
+git diff --check
+```
+
+Tool build scripts still discover plugin packages exclusively under `tools/*`.
+When browser, fetch, and search later depend on this package, package artifact
+proof should confirm each tool still stages one plugin dylib and no extra shared
+dylib.

--- a/Shared/OsaurusToolSecurity/Sources/OsaurusToolSecurity/WebSafety.swift
+++ b/Shared/OsaurusToolSecurity/Sources/OsaurusToolSecurity/WebSafety.swift
@@ -1,0 +1,1010 @@
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+#endif
+
+public enum WebSafetyErrorCode: String, Equatable {
+    case ssrfBlocked = "SSRF_BLOCKED"
+    case secretInURL = "SECRET_IN_URL"
+    case unsafeScheme = "UNSAFE_SCHEME"
+    case downloadPathInvalid = "DOWNLOAD_PATH_INVALID"
+}
+
+public struct WebSafetyError: Error, Equatable, LocalizedError {
+    public let code: WebSafetyErrorCode
+    public let message: String
+    public let redactedURL: String?
+
+    public init(code: WebSafetyErrorCode, message: String, redactedURL: String? = nil) {
+        self.code = code
+        self.message = message
+        self.redactedURL = redactedURL
+    }
+
+    public var errorDescription: String? {
+        message
+    }
+}
+
+public struct RedactionResult<Value> {
+    public let value: Value
+    public let redacted: Bool
+
+    public init(value: Value, redacted: Bool) {
+        self.value = value
+        self.redacted = redacted
+    }
+}
+
+public struct URLPolicyOptions: Equatable {
+    public var allowPrivateNetwork: Bool
+    public var allowAboutBlank: Bool
+    public var resolveHostnames: Bool
+
+    public init(
+        allowPrivateNetwork: Bool = false,
+        allowAboutBlank: Bool = false,
+        resolveHostnames: Bool = true
+    ) {
+        self.allowPrivateNetwork = allowPrivateNetwork
+        self.allowAboutBlank = allowAboutBlank
+        self.resolveHostnames = resolveHostnames
+    }
+}
+
+public struct URLPolicyDecision: Equatable {
+    public let url: URL
+    public let redactedURL: String
+    public let host: String?
+    public let resolvedAddresses: [String]
+    public let isAboutBlank: Bool
+    public let warnings: [String]
+
+    public init(
+        url: URL,
+        redactedURL: String,
+        host: String?,
+        resolvedAddresses: [String],
+        isAboutBlank: Bool,
+        warnings: [String]
+    ) {
+        self.url = url
+        self.redactedURL = redactedURL
+        self.host = host
+        self.resolvedAddresses = resolvedAddresses
+        self.isAboutBlank = isAboutBlank
+        self.warnings = warnings
+    }
+}
+
+public struct SystemHostResolver {
+    public static func resolve(_ host: String) -> [String] {
+        var hints = addrinfo(
+            ai_flags: 0,
+            ai_family: AF_UNSPEC,
+            ai_socktype: SOCK_STREAM,
+            ai_protocol: IPPROTO_TCP,
+            ai_addrlen: 0,
+            ai_canonname: nil,
+            ai_addr: nil,
+            ai_next: nil
+        )
+        var info: UnsafeMutablePointer<addrinfo>?
+        let status = getaddrinfo(host, nil, &hints, &info)
+        guard status == 0, let head = info else { return [] }
+        defer { freeaddrinfo(head) }
+
+        var results: [String] = []
+        var cursor: UnsafeMutablePointer<addrinfo>? = head
+        while let node = cursor {
+            let entry = node.pointee
+            if let addr = entry.ai_addr {
+                var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                let rc = getnameinfo(
+                    addr,
+                    socklen_t(entry.ai_addrlen),
+                    &buffer,
+                    socklen_t(buffer.count),
+                    nil,
+                    0,
+                    NI_NUMERICHOST
+                )
+                if rc == 0 {
+                    let name = String(cString: buffer)
+                    if !name.isEmpty && !results.contains(name) {
+                        results.append(name)
+                    }
+                }
+            }
+            cursor = entry.ai_next
+        }
+        return results
+    }
+}
+
+public struct URLPolicy {
+    public typealias Resolver = (String) -> [String]
+
+    private let resolver: Resolver
+
+    public init(resolver: @escaping Resolver = SystemHostResolver.resolve) {
+        self.resolver = resolver
+    }
+
+    public func validate(_ rawURL: String, options: URLPolicyOptions = URLPolicyOptions()) throws -> URLPolicyDecision {
+        guard let url = URL(string: rawURL) else {
+            throw WebSafetyError(
+                code: .unsafeScheme,
+                message: "URL is invalid or missing a supported scheme.",
+                redactedURL: WebSafetyRedactor.redactURL(rawURL).value
+            )
+        }
+        return try validate(url, options: options)
+    }
+
+    public func validate(_ url: URL, options: URLPolicyOptions = URLPolicyOptions()) throws -> URLPolicyDecision {
+        let redacted = WebSafetyRedactor.redactURL(url.absoluteString)
+        let redactedURL = redacted.value
+        let warnings = redacted.redacted ? ["credential-looking URL components were redacted"] : []
+
+        if isAboutBlank(url) {
+            if options.allowAboutBlank {
+                return URLPolicyDecision(
+                    url: url,
+                    redactedURL: redactedURL,
+                    host: nil,
+                    resolvedAddresses: [],
+                    isAboutBlank: true,
+                    warnings: warnings
+                )
+            }
+            throw WebSafetyError(
+                code: .unsafeScheme,
+                message: "about:blank is allowed only for explicitly opted-in browser flows.",
+                redactedURL: redactedURL
+            )
+        }
+
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            let got = url.scheme ?? "(missing)"
+            throw WebSafetyError(
+                code: .unsafeScheme,
+                message: "Only http and https URLs are allowed; got '\(got)'.",
+                redactedURL: redactedURL
+            )
+        }
+
+        if URLPolicy.hasUserInfo(url) {
+            throw WebSafetyError(
+                code: .secretInURL,
+                message: "URL userinfo is not allowed because it can embed credentials.",
+                redactedURL: redactedURL
+            )
+        }
+
+        guard let rawHost = URLComponents(url: url, resolvingAgainstBaseURL: false)?.host ?? url.host,
+            !rawHost.isEmpty
+        else {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: "URL has no host component.",
+                redactedURL: redactedURL
+            )
+        }
+
+        let host = HostNormalizer.normalize(rawHost)
+        if MetadataEndpoint.isBlockedHostname(host) {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: "Cloud metadata endpoint host '\(host)' is blocked.",
+                redactedURL: redactedURL
+            )
+        }
+
+        if let ipv4 = IPv4Address.parseFlexible(host) {
+            try enforceIPv4(ipv4, host: host, options: options, redactedURL: redactedURL)
+            return URLPolicyDecision(
+                url: url,
+                redactedURL: redactedURL,
+                host: host,
+                resolvedAddresses: [ipv4.presentation],
+                isAboutBlank: false,
+                warnings: warnings
+            )
+        }
+
+        if let ipv6 = IPv6Address.parse(host) {
+            try enforceIPv6(ipv6, host: host, options: options, redactedURL: redactedURL)
+            return URLPolicyDecision(
+                url: url,
+                redactedURL: redactedURL,
+                host: host,
+                resolvedAddresses: [ipv6.presentation],
+                isAboutBlank: false,
+                warnings: warnings
+            )
+        }
+
+        if !options.allowPrivateNetwork && HostNormalizer.isBlockedLocalName(host) {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: "Local/private hostname '\(host)' is blocked.",
+                redactedURL: redactedURL
+            )
+        }
+
+        let resolved = options.resolveHostnames ? resolver(host) : []
+        if options.resolveHostnames && resolved.isEmpty {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: "Host '\(host)' did not resolve to any address for SSRF validation.",
+                redactedURL: redactedURL
+            )
+        }
+        for resolvedHost in resolved.map(HostNormalizer.normalize) {
+            if let ipv4 = IPv4Address.parseFlexible(resolvedHost) {
+                try enforceIPv4(ipv4, host: host, resolvedHost: resolvedHost, options: options, redactedURL: redactedURL)
+                continue
+            }
+            if let ipv6 = IPv6Address.parse(resolvedHost) {
+                try enforceIPv6(ipv6, host: host, resolvedHost: resolvedHost, options: options, redactedURL: redactedURL)
+            }
+        }
+
+        return URLPolicyDecision(
+            url: url,
+            redactedURL: redactedURL,
+            host: host,
+            resolvedAddresses: resolved,
+            isAboutBlank: false,
+            warnings: warnings
+        )
+    }
+
+    private func enforceIPv4(
+        _ ipv4: IPv4Address,
+        host: String,
+        resolvedHost: String? = nil,
+        options: URLPolicyOptions,
+        redactedURL: String
+    ) throws {
+        if MetadataEndpoint.isBlockedIPv4(ipv4.value) {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: blockMessage(host: host, resolvedHost: resolvedHost, reason: "cloud metadata IPv4 \(ipv4.presentation)"),
+                redactedURL: redactedURL
+            )
+        }
+        if !options.allowPrivateNetwork && IPv4Address.isBlockedNetwork(ipv4.value) {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: blockMessage(host: host, resolvedHost: resolvedHost, reason: "private/reserved IPv4 \(ipv4.presentation)"),
+                redactedURL: redactedURL
+            )
+        }
+    }
+
+    private func enforceIPv6(
+        _ ipv6: IPv6Address,
+        host: String,
+        resolvedHost: String? = nil,
+        options: URLPolicyOptions,
+        redactedURL: String
+    ) throws {
+        if MetadataEndpoint.isBlockedIPv6(ipv6) {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: blockMessage(host: host, resolvedHost: resolvedHost, reason: "cloud metadata IPv6 \(ipv6.presentation)"),
+                redactedURL: redactedURL
+            )
+        }
+        if !options.allowPrivateNetwork && IPv6Address.isBlockedNetwork(ipv6) {
+            throw WebSafetyError(
+                code: .ssrfBlocked,
+                message: blockMessage(host: host, resolvedHost: resolvedHost, reason: "private/reserved IPv6 \(ipv6.presentation)"),
+                redactedURL: redactedURL
+            )
+        }
+    }
+
+    private func blockMessage(host: String, resolvedHost: String?, reason: String) -> String {
+        if let resolvedHost {
+            return "Host '\(host)' resolves to blocked \(reason) via \(resolvedHost)."
+        }
+        return "Host '\(host)' is blocked as \(reason)."
+    }
+
+    private func isAboutBlank(_ url: URL) -> Bool {
+        url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "about:blank"
+    }
+
+    private static func hasUserInfo(_ url: URL) -> Bool {
+        if let user = url.user, !user.isEmpty { return true }
+        if let password = url.password, !password.isEmpty { return true }
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            if let user = components.user, !user.isEmpty { return true }
+            if let password = components.password, !password.isEmpty { return true }
+        }
+        return false
+    }
+}
+
+public struct RedirectDecision: Equatable {
+    public let target: URLPolicyDecision
+    public let headers: [String: String]
+    public let strippedSensitiveHeaders: Bool
+
+    public init(target: URLPolicyDecision, headers: [String: String], strippedSensitiveHeaders: Bool) {
+        self.target = target
+        self.headers = headers
+        self.strippedSensitiveHeaders = strippedSensitiveHeaders
+    }
+}
+
+public struct RedirectPolicy {
+    private let urlPolicy: URLPolicy
+
+    public init(urlPolicy: URLPolicy = URLPolicy()) {
+        self.urlPolicy = urlPolicy
+    }
+
+    public func evaluate(
+        from currentURL: URL,
+        to targetURL: URL,
+        headers: [String: String],
+        options: URLPolicyOptions = URLPolicyOptions()
+    ) throws -> RedirectDecision {
+        let target = try urlPolicy.validate(targetURL, options: options)
+        let shouldStrip = !sameOrigin(currentURL, targetURL) || isDowngrade(from: currentURL, to: targetURL)
+        guard shouldStrip else {
+            return RedirectDecision(target: target, headers: headers, strippedSensitiveHeaders: false)
+        }
+
+        var stripped: [String: String] = [:]
+        var didStrip = false
+        for (name, value) in headers {
+            if WebSafetyRedactor.isSensitiveHeaderName(name) {
+                didStrip = true
+            } else {
+                stripped[name] = value
+            }
+        }
+        return RedirectDecision(target: target, headers: stripped, strippedSensitiveHeaders: didStrip)
+    }
+
+    private func sameOrigin(_ lhs: URL, _ rhs: URL) -> Bool {
+        let leftScheme = lhs.scheme?.lowercased()
+        let rightScheme = rhs.scheme?.lowercased()
+        guard leftScheme == rightScheme else { return false }
+        let leftHost = (URLComponents(url: lhs, resolvingAgainstBaseURL: false)?.host ?? lhs.host ?? "").lowercased()
+        let rightHost = (URLComponents(url: rhs, resolvingAgainstBaseURL: false)?.host ?? rhs.host ?? "").lowercased()
+        return leftHost == rightHost && effectivePort(lhs) == effectivePort(rhs)
+    }
+
+    private func isDowngrade(from currentURL: URL, to targetURL: URL) -> Bool {
+        currentURL.scheme?.lowercased() == "https" && targetURL.scheme?.lowercased() == "http"
+    }
+
+    private func effectivePort(_ url: URL) -> Int? {
+        if let port = url.port { return port }
+        switch url.scheme?.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return nil
+        }
+    }
+}
+
+public enum WebSafetyRedactor {
+    private static let redacted = "<redacted>"
+    private static let urlQueryRedacted = "REDACTED"
+
+    public static func containsCredentials(inURL rawURL: String) -> Bool {
+        redactURL(rawURL).redacted
+    }
+
+    public static func redactURL(_ rawURL: String) -> RedactionResult<String> {
+        guard var components = URLComponents(string: rawURL) else {
+            let redactedText = redactCredentialPairs(in: rawURL)
+            return RedactionResult(value: redactedText.value, redacted: redactedText.redacted)
+        }
+
+        var didRedact = false
+        if components.user != nil || components.password != nil {
+            components.user = nil
+            components.password = nil
+            didRedact = true
+        }
+
+        if let items = components.queryItems, !items.isEmpty {
+            let rewritten = items.map { item -> URLQueryItem in
+                if isCredentialQueryName(item.name) || looksLikeSecretValue(item.value) {
+                    didRedact = true
+                    return URLQueryItem(name: item.name, value: urlQueryRedacted)
+                }
+                return item
+            }
+            components.queryItems = rewritten
+        } else if let percentEncodedQuery = components.percentEncodedQuery, !percentEncodedQuery.isEmpty {
+            let redactedQuery = redactCredentialPairs(in: percentEncodedQuery)
+            if redactedQuery.redacted {
+                components.percentEncodedQuery = redactedQuery.value
+                didRedact = true
+            }
+        }
+
+        if let percentEncodedFragment = components.percentEncodedFragment, !percentEncodedFragment.isEmpty {
+            let redactedFragment = redactCredentialPairs(in: percentEncodedFragment)
+            if redactedFragment.redacted {
+                components.percentEncodedFragment = redactedFragment.value
+                didRedact = true
+            }
+        }
+
+        return RedactionResult(value: components.string ?? rawURL, redacted: didRedact)
+    }
+
+    public static func redactHeaders(_ headers: [String: String]) -> RedactionResult<[String: String]> {
+        var output: [String: String] = [:]
+        var didRedact = false
+        for (name, value) in headers {
+            if isSensitiveHeaderName(name) {
+                output[name] = redacted
+                didRedact = true
+            } else {
+                let text = redactText(value)
+                output[name] = text.value
+                didRedact = didRedact || text.redacted
+            }
+        }
+        return RedactionResult(value: output, redacted: didRedact)
+    }
+
+    public static func redactCookieHeader(_ cookie: String) -> RedactionResult<String> {
+        let parts = cookie.split(separator: ";", omittingEmptySubsequences: false)
+        var didRedact = false
+        let rewritten = parts.map { part -> String in
+            let piece = String(part)
+            let leading = piece.prefix { $0 == " " || $0 == "\t" }
+            let trimmed = piece.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let equals = trimmed.firstIndex(of: "=") else {
+                return piece
+            }
+            let name = String(trimmed[..<equals])
+            let lower = name.lowercased()
+            if setCookieAttributeNames.contains(lower) {
+                return piece
+            }
+            didRedact = true
+            return "\(leading)\(name)=\(redacted)"
+        }.joined(separator: ";")
+        return RedactionResult(value: rewritten, redacted: didRedact)
+    }
+
+    public static func redactText(_ text: String) -> RedactionResult<String> {
+        var output = text
+        var didRedact = false
+
+        let urlPattern = #"https?://[^\s<>"']+"#
+        if let regex = try? NSRegularExpression(pattern: urlPattern, options: [.caseInsensitive]) {
+            let matches = regex.matches(in: output, range: NSRange(output.startIndex..., in: output))
+            for match in matches.reversed() {
+                guard let range = Range(match.range, in: output) else { continue }
+                let candidate = String(output[range])
+                let redactedURL = redactURL(candidate)
+                if redactedURL.redacted {
+                    output.replaceSubrange(range, with: redactedURL.value)
+                    didRedact = true
+                }
+            }
+        }
+
+        let headerPatterns = [
+            #"(?i)\b(authorization|proxy-authorization|x-api-key|api-key|x-auth-token|x-csrf-token)\s*:\s*([^\r\n]+)"#,
+            #"(?i)\b(bearer|basic)\s+([A-Za-z0-9._~+/=-]{8,})"#,
+        ]
+        for pattern in headerPatterns {
+            let result = replaceRegex(pattern, in: output) { match in
+                if match.count == 3 {
+                    didRedact = true
+                    return "\(match[1]) \(pattern.contains(":") ? ":" : "") \(redacted)"
+                        .replacingOccurrences(of: "  ", with: " ")
+                        .replacingOccurrences(of: " : ", with: ": ")
+                }
+                return match[0]
+            }
+            output = result
+        }
+
+        let pairs = redactCredentialPairs(in: output)
+        if pairs.redacted {
+            output = pairs.value
+            didRedact = true
+        }
+
+        return RedactionResult(value: output, redacted: didRedact)
+    }
+
+    public static func isSensitiveHeaderName(_ name: String) -> Bool {
+        let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        if sensitiveHeaderNames.contains(normalized) { return true }
+        return normalized.contains("token")
+            || normalized.contains("secret")
+            || normalized.contains("api-key")
+            || normalized.contains("apikey")
+            || normalized.contains("credential")
+    }
+
+    private static func redactCredentialPairs(in text: String) -> RedactionResult<String> {
+        let pattern = #"(?i)\b(access_token|refresh_token|id_token|api_key|apikey|x-api-key|key|token|secret|signature|sig|password|passwd|pwd|x-amz-signature|x-amz-credential|x-amz-security-token|x-goog-signature|x-goog-credential|x-goog-security-token)=([^&;\s]+)"#
+        var didRedact = false
+        let output = replaceRegex(pattern, in: text) { match in
+            guard match.count == 3 else { return match[0] }
+            didRedact = true
+            return "\(match[1])=\(urlQueryRedacted)"
+        }
+        return RedactionResult(value: output, redacted: didRedact)
+    }
+
+    private static func isCredentialQueryName(_ name: String) -> Bool {
+        let decoded = percentDecodeRepeated(name).lowercased()
+        let normalized = decoded.replacingOccurrences(of: "_", with: "-")
+        if credentialQueryNames.contains(decoded) || credentialQueryNames.contains(normalized) {
+            return true
+        }
+        return normalized.contains("token")
+            || normalized.contains("secret")
+            || normalized.contains("api-key")
+            || normalized.contains("apikey")
+            || normalized.contains("credential")
+            || normalized == "key"
+            || normalized == "signature"
+            || normalized == "sig"
+            || normalized == "password"
+    }
+
+    private static func looksLikeSecretValue(_ value: String?) -> Bool {
+        guard let value, !value.isEmpty else { return false }
+        let decoded = percentDecodeRepeated(value)
+        let lower = decoded.lowercased()
+        if secretPrefixes.contains(where: { lower.hasPrefix($0) }) {
+            return true
+        }
+        if decoded.hasPrefix("AKIA") || decoded.hasPrefix("ASIA") {
+            return decoded.count >= 16
+        }
+        return false
+    }
+
+    private static func percentDecodeRepeated(_ value: String) -> String {
+        var current = value
+        for _ in 0..<3 {
+            guard let decoded = current.removingPercentEncoding, decoded != current else { break }
+            current = decoded
+        }
+        return current
+    }
+
+    private static func replaceRegex(
+        _ pattern: String,
+        in text: String,
+        transform: ([String]) -> String
+    ) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return text
+        }
+        var output = text
+        let matches = regex.matches(in: output, range: NSRange(output.startIndex..., in: output))
+        for match in matches.reversed() {
+            var groups: [String] = []
+            for index in 0..<match.numberOfRanges {
+                let range = match.range(at: index)
+                if range.location == NSNotFound {
+                    groups.append("")
+                } else if let swiftRange = Range(range, in: output) {
+                    groups.append(String(output[swiftRange]))
+                } else {
+                    groups.append("")
+                }
+            }
+            guard let range = Range(match.range(at: 0), in: output) else { continue }
+            output.replaceSubrange(range, with: transform(groups))
+        }
+        return output
+    }
+
+    private static let sensitiveHeaderNames: Set<String> = [
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "set-cookie",
+        "x-api-key",
+        "api-key",
+        "x-auth-token",
+        "x-csrf-token",
+        "x-amz-security-token",
+        "x-goog-security-token",
+    ]
+
+    private static let setCookieAttributeNames: Set<String> = [
+        "domain",
+        "expires",
+        "max-age",
+        "path",
+        "priority",
+        "samesite",
+        "version",
+    ]
+
+    private static let credentialQueryNames: Set<String> = [
+        "access_token",
+        "access-token",
+        "refresh_token",
+        "refresh-token",
+        "id_token",
+        "id-token",
+        "api_key",
+        "api-key",
+        "apikey",
+        "key",
+        "token",
+        "secret",
+        "signature",
+        "sig",
+        "password",
+        "passwd",
+        "pwd",
+        "x-amz-signature",
+        "x-amz-credential",
+        "x-amz-security-token",
+        "x-goog-signature",
+        "x-goog-credential",
+        "x-goog-security-token",
+        "awsaccesskeyid",
+    ]
+
+    private static let secretPrefixes: [String] = [
+        "sk-",
+        "ghp_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "github_pat_",
+        "xoxb-",
+        "xoxp-",
+        "ya29.",
+        "bearer ",
+        "basic ",
+    ]
+}
+
+public struct DownloadPathValidator {
+    private let baseDirectory: URL
+
+    public init(baseDirectory: URL) {
+        self.baseDirectory = baseDirectory
+    }
+
+    public func resolve(
+        requestedFilename: String?,
+        sourceURL: URL? = nil,
+        defaultFilename: String = "download"
+    ) throws -> URL {
+        let rawCandidate: String
+        if let requestedFilename {
+            rawCandidate = requestedFilename
+        } else {
+            rawCandidate = sourceURL?.lastPathComponent.nilIfEmpty ?? defaultFilename
+        }
+        let candidate = rawCandidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        try Self.validateFilename(candidate)
+
+        let base = baseDirectory.standardizedFileURL.resolvingSymlinksInPath()
+        let target = base.appendingPathComponent(candidate, isDirectory: false).standardizedFileURL
+        let resolvedTarget: URL
+        if let symlinkDestination = try? FileManager.default.destinationOfSymbolicLink(atPath: target.path) {
+            resolvedTarget = URL(
+                fileURLWithPath: symlinkDestination,
+                relativeTo: target.deletingLastPathComponent()
+            )
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        } else {
+            resolvedTarget = target.resolvingSymlinksInPath()
+        }
+        let basePath = base.path
+        let targetPath = resolvedTarget.path
+        guard targetPath.hasPrefix(basePath + "/") else {
+            throw WebSafetyError(
+                code: .downloadPathInvalid,
+                message: "Download target escapes the configured directory."
+            )
+        }
+        return target
+    }
+
+    private static func validateFilename(_ filename: String) throws {
+        let invalid = filename.isEmpty
+            || filename.hasPrefix(".")
+            || filename.hasPrefix("~")
+            || filename.contains("/")
+            || filename.contains("\\")
+            || filename.contains("..")
+            || filename.contains("\u{0}")
+            || URL(fileURLWithPath: filename).isFileURL && filename.hasPrefix("/")
+        if invalid {
+            throw WebSafetyError(
+                code: .downloadPathInvalid,
+                message: "Download filename must be a plain non-hidden filename inside the configured directory."
+            )
+        }
+    }
+}
+
+private enum HostNormalizer {
+    static func normalize(_ host: String) -> String {
+        var normalized = decodePercentRepeated(host)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if normalized.hasPrefix("[") && normalized.hasSuffix("]") {
+            normalized = String(normalized.dropFirst().dropLast())
+        }
+        if let zoneIndex = normalized.firstIndex(of: "%") {
+            normalized = String(normalized[..<zoneIndex])
+        }
+        while normalized.hasSuffix(".") {
+            normalized.removeLast()
+        }
+        return normalized
+    }
+
+    static func isBlockedLocalName(_ host: String) -> Bool {
+        host == "localhost"
+            || host == "ip6-localhost"
+            || host == "ip6-loopback"
+            || host == "broadcasthost"
+            || host.hasSuffix(".local")
+            || host.hasSuffix(".internal")
+    }
+
+    private static func decodePercentRepeated(_ value: String) -> String {
+        var current = value
+        for _ in 0..<3 {
+            guard let decoded = current.removingPercentEncoding, decoded != current else { break }
+            current = decoded
+        }
+        return current
+    }
+}
+
+private struct IPv4Address: Equatable {
+    let value: UInt32
+
+    var presentation: String {
+        [
+            (value >> 24) & 0xff,
+            (value >> 16) & 0xff,
+            (value >> 8) & 0xff,
+            value & 0xff,
+        ].map(String.init).joined(separator: ".")
+    }
+
+    static func parseFlexible(_ host: String) -> IPv4Address? {
+        guard !host.contains(":") else { return nil }
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard (1...4).contains(parts.count), !parts.contains(where: { $0.isEmpty }) else {
+            return nil
+        }
+        let numbers = parts.compactMap { parseIPv4Component(String($0)) }
+        guard numbers.count == parts.count else { return nil }
+
+        let value: UInt64
+        switch numbers.count {
+        case 1:
+            guard numbers[0] <= 0xffff_ffff else { return nil }
+            value = numbers[0]
+        case 2:
+            guard numbers[0] <= 0xff, numbers[1] <= 0x00ff_ffff else { return nil }
+            value = (numbers[0] << 24) | numbers[1]
+        case 3:
+            guard numbers[0] <= 0xff, numbers[1] <= 0xff, numbers[2] <= 0xffff else { return nil }
+            value = (numbers[0] << 24) | (numbers[1] << 16) | numbers[2]
+        case 4:
+            guard numbers.allSatisfy({ $0 <= 0xff }) else { return nil }
+            value = (numbers[0] << 24) | (numbers[1] << 16) | (numbers[2] << 8) | numbers[3]
+        default:
+            return nil
+        }
+        return IPv4Address(value: UInt32(value))
+    }
+
+    static func isBlockedNetwork(_ value: UInt32) -> Bool {
+        blockedRanges.contains { range in
+            (value & range.mask) == (range.network & range.mask)
+        }
+    }
+
+    private static func parseIPv4Component(_ component: String) -> UInt64? {
+        let lower = component.lowercased()
+        let base: Int
+        let digits: String
+        if lower.hasPrefix("0x") {
+            base = 16
+            digits = String(lower.dropFirst(2))
+        } else if lower.count > 1 && lower.hasPrefix("0") {
+            base = 8
+            digits = String(lower.dropFirst())
+        } else {
+            base = 10
+            digits = lower
+        }
+        guard !digits.isEmpty else { return nil }
+        return UInt64(digits, radix: base)
+    }
+
+    private static let blockedRanges: [(network: UInt32, mask: UInt32)] = [
+        (0x0000_0000, 0xff00_0000),  // 0.0.0.0/8
+        (0x0a00_0000, 0xff00_0000),  // 10.0.0.0/8
+        (0x6440_0000, 0xffc0_0000),  // 100.64.0.0/10
+        (0x7f00_0000, 0xff00_0000),  // 127.0.0.0/8
+        (0xa9fe_0000, 0xffff_0000),  // 169.254.0.0/16
+        (0xac10_0000, 0xfff0_0000),  // 172.16.0.0/12
+        (0xc000_0000, 0xffff_ff00),  // 192.0.0.0/24
+        (0xc000_0200, 0xffff_ff00),  // 192.0.2.0/24
+        (0xc0a8_0000, 0xffff_0000),  // 192.168.0.0/16
+        (0xc612_0000, 0xfffe_0000),  // 198.18.0.0/15
+        (0xc633_6400, 0xffff_ff00),  // 198.51.100.0/24
+        (0xcb00_7100, 0xffff_ff00),  // 203.0.113.0/24
+        (0xe000_0000, 0xf000_0000),  // 224.0.0.0/4
+        (0xf000_0000, 0xf000_0000),  // 240.0.0.0/4
+        (0xffff_ffff, 0xffff_ffff),  // 255.255.255.255/32
+    ]
+}
+
+private struct IPv6Address: Equatable {
+    let bytes: [UInt8]
+    let presentation: String
+
+    static func parse(_ host: String) -> IPv6Address? {
+        guard host.contains(":") else { return nil }
+        var addr = in6_addr()
+        let rc = host.withCString { inet_pton(AF_INET6, $0, &addr) }
+        guard rc == 1 else { return nil }
+        let bytes = withUnsafeBytes(of: addr) { Array($0) }
+        return IPv6Address(bytes: bytes, presentation: host)
+    }
+
+    static func isBlockedNetwork(_ address: IPv6Address) -> Bool {
+        let bytes = address.bytes
+        guard bytes.count == 16 else { return true }
+
+        if bytes.allSatisfy({ $0 == 0 }) { return true }  // ::/128
+        if bytes.prefix(15).allSatisfy({ $0 == 0 }) && bytes[15] == 1 { return true }  // ::1/128
+        if bytes[0] == 0xff { return true }  // ff00::/8 multicast
+        if bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80 { return true }  // fe80::/10 link-local
+        if (bytes[0] & 0xfe) == 0xfc { return true }  // fc00::/7 unique-local
+        if bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0xc0 { return true }  // fec0::/10 site-local
+        if bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8 {
+            return true  // 2001:db8::/32 documentation
+        }
+
+        for embedded in embeddedIPv4Addresses(address) {
+            if IPv4Address.isBlockedNetwork(embedded) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    static func embeddedIPv4(_ address: IPv6Address) -> UInt32? {
+        embeddedIPv4Addresses(address).first
+    }
+
+    static func embeddedIPv4Addresses(_ address: IPv6Address) -> [UInt32] {
+        let bytes = address.bytes
+        guard bytes.count == 16 else { return [] }
+
+        if isIPv4Mapped(address) || isIPv4Compatible(address) || isWellKnownNAT64(address) {
+            return [uint32(bytes[12], bytes[13], bytes[14], bytes[15])]
+        }
+
+        if is6to4(address) {
+            return [uint32(bytes[2], bytes[3], bytes[4], bytes[5])]
+        }
+
+        if isTeredo(address) {
+            let server = uint32(bytes[4], bytes[5], bytes[6], bytes[7])
+            let client = uint32(~bytes[12], ~bytes[13], ~bytes[14], ~bytes[15])
+            return [server, client]
+        }
+
+        return []
+    }
+
+    private static func isIPv4Mapped(_ address: IPv6Address) -> Bool {
+        let bytes = address.bytes
+        return bytes.count == 16
+            && bytes[0..<10].allSatisfy { $0 == 0 }
+            && bytes[10] == 0xff
+            && bytes[11] == 0xff
+    }
+
+    private static func isIPv4Compatible(_ address: IPv6Address) -> Bool {
+        let bytes = address.bytes
+        return bytes.count == 16
+            && bytes[0..<12].allSatisfy { $0 == 0 }
+            && !bytes[12..<16].allSatisfy { $0 == 0 }
+    }
+
+    private static func isWellKnownNAT64(_ address: IPv6Address) -> Bool {
+        let bytes = address.bytes
+        return bytes.count == 16
+            && bytes[0] == 0x00
+            && bytes[1] == 0x64
+            && bytes[2] == 0xff
+            && bytes[3] == 0x9b
+            && bytes[4..<12].allSatisfy { $0 == 0 }
+    }
+
+    private static func is6to4(_ address: IPv6Address) -> Bool {
+        let bytes = address.bytes
+        return bytes.count == 16 && bytes[0] == 0x20 && bytes[1] == 0x02
+    }
+
+    private static func isTeredo(_ address: IPv6Address) -> Bool {
+        let bytes = address.bytes
+        return bytes.count == 16 && bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0 && bytes[3] == 0
+    }
+
+    private static func uint32(_ b0: UInt8, _ b1: UInt8, _ b2: UInt8, _ b3: UInt8) -> UInt32 {
+        (UInt32(b0) << 24)
+            | (UInt32(b1) << 16)
+            | (UInt32(b2) << 8)
+            | UInt32(b3)
+    }
+}
+
+private enum MetadataEndpoint {
+    static func isBlockedHostname(_ host: String) -> Bool {
+        metadataHostnames.contains(host)
+    }
+
+    static func isBlockedIPv4(_ value: UInt32) -> Bool {
+        metadataIPv4.contains(value)
+    }
+
+    static func isBlockedIPv6(_ address: IPv6Address) -> Bool {
+        if address.bytes == awsIPv6Metadata { return true }
+        for embedded in IPv6Address.embeddedIPv4Addresses(address) where isBlockedIPv4(embedded) {
+            return true
+        }
+        return false
+    }
+
+    private static let metadataHostnames: Set<String> = [
+        "metadata",
+        "metadata.google.internal",
+        "metadata.amazonaws.com",
+        "instance-data.ec2.internal",
+    ]
+
+    private static let metadataIPv4: Set<UInt32> = [
+        0xa9fe_a9fe,  // 169.254.169.254
+        0xa9fe_aa02,  // 169.254.170.2
+        0x6464_64c8,  // 100.100.100.200
+    ]
+
+    private static let awsIPv6Metadata: [UInt8] = {
+        IPv6Address.parse("fd00:ec2::254")?.bytes ?? []
+    }()
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/DownloadPathValidatorTests.swift
+++ b/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/DownloadPathValidatorTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import OsaurusToolSecurity
+
+final class DownloadPathValidatorTests: XCTestCase {
+    private var tempDir: URL!
+    private var validator: DownloadPathValidator!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        validator = DownloadPathValidator(baseDirectory: tempDir)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+    }
+
+    func testAcceptsPlainFilenameInsideBaseDirectory() throws {
+        let target = try validator.resolve(requestedFilename: "report.pdf")
+        XCTAssertEqual(target.deletingLastPathComponent().standardizedFileURL.path, tempDir.standardizedFileURL.path)
+        XCTAssertEqual(target.lastPathComponent, "report.pdf")
+    }
+
+    func testFallsBackToSourceURLBasename() throws {
+        let source = URL(string: "https://example.com/downloads/archive.zip")!
+        let target = try validator.resolve(requestedFilename: nil, sourceURL: source)
+        XCTAssertEqual(target.lastPathComponent, "archive.zip")
+    }
+
+    func testRejectsAbsolutePathsParentTraversalHiddenTildeAndSeparators() {
+        for candidate in [
+            "/etc/passwd",
+            "../secret",
+            "safe..name",
+            ".secret",
+            "~/secret",
+            "nested/file.txt",
+            "nested\\file.txt",
+            "",
+        ] {
+            assertRejected(candidate)
+        }
+    }
+
+    func testRejectsExistingSymlinkThatEscapesBaseDirectory() throws {
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let link = tempDir.appendingPathComponent("safe.txt")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        assertRejected("safe.txt")
+    }
+
+    private func assertRejected(
+        _ filename: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        do {
+            _ = try validator.resolve(requestedFilename: filename)
+            XCTFail("Expected \(filename) to be rejected", file: file, line: line)
+        } catch let error as WebSafetyError {
+            XCTAssertEqual(error.code, .downloadPathInvalid, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/RedactionTests.swift
+++ b/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/RedactionTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+
+@testable import OsaurusToolSecurity
+
+final class RedactionTests: XCTestCase {
+    func testRedactsURLUserInfoAndCredentialQueries() {
+        let result = WebSafetyRedactor.redactURL(
+            "https://user:pass@example.com/path?token=abc123&q=visible"
+        )
+        XCTAssertTrue(result.redacted)
+        XCTAssertEqual(result.value, "https://example.com/path?token=REDACTED&q=visible")
+    }
+
+    func testDoesNotRedactBenignQuery() {
+        let result = WebSafetyRedactor.redactURL("https://example.com/search?q=osaurus&page=1")
+        XCTAssertFalse(result.redacted)
+        XCTAssertEqual(result.value, "https://example.com/search?q=osaurus&page=1")
+    }
+
+    func testContainsCredentialsInURL() {
+        XCTAssertTrue(WebSafetyRedactor.containsCredentials(inURL: "https://example.com/?api_key=abc"))
+        XCTAssertFalse(WebSafetyRedactor.containsCredentials(inURL: "https://example.com/?q=abc"))
+    }
+
+    func testRedactsSignedCloudURLParameters() {
+        let result = WebSafetyRedactor.redactURL(
+            "https://s3.amazonaws.com/bucket/file?X-Amz-Signature=sig&X-Amz-Credential=cred&Expires=123"
+        )
+        XCTAssertTrue(result.redacted)
+        XCTAssertTrue(result.value.contains("X-Amz-Signature=REDACTED"))
+        XCTAssertTrue(result.value.contains("X-Amz-Credential=REDACTED"))
+        XCTAssertTrue(result.value.contains("Expires=123"))
+    }
+
+    func testRedactsCredentialFragments() {
+        let result = WebSafetyRedactor.redactURL(
+            "https://example.com/callback#access_token=abc123&id_token=jwt-value&state=visible"
+        )
+        XCTAssertTrue(result.redacted)
+        XCTAssertFalse(result.value.contains("abc123"))
+        XCTAssertFalse(result.value.contains("jwt-value"))
+        XCTAssertTrue(result.value.contains("access_token=REDACTED"))
+        XCTAssertTrue(result.value.contains("id_token=REDACTED"))
+        XCTAssertTrue(result.value.contains("state=visible"))
+    }
+
+    func testRedactsPercentDecodedSecretPrefixesInURLValues() {
+        let result = WebSafetyRedactor.redactURL("https://example.com/?continue=ghp_%255Fsecret")
+        XCTAssertTrue(result.redacted)
+        XCTAssertTrue(result.value.contains("continue=REDACTED"))
+    }
+
+    func testHeaderRedactionCoversCredentialHeadersCaseInsensitively() {
+        let result = WebSafetyRedactor.redactHeaders([
+            "Authorization": "Bearer token",
+            "Cookie": "session=abc",
+            "Set-Cookie": "session=abc; Path=/",
+            "Proxy-Authorization": "Basic abc",
+            "X-Api-Key": "secret",
+            "X_Api_Key": "secret",
+            "Accept": "application/json",
+        ])
+        XCTAssertTrue(result.redacted)
+        XCTAssertEqual(result.value["Authorization"], "<redacted>")
+        XCTAssertEqual(result.value["Cookie"], "<redacted>")
+        XCTAssertEqual(result.value["Set-Cookie"], "<redacted>")
+        XCTAssertEqual(result.value["Proxy-Authorization"], "<redacted>")
+        XCTAssertEqual(result.value["X-Api-Key"], "<redacted>")
+        XCTAssertEqual(result.value["X_Api_Key"], "<redacted>")
+        XCTAssertEqual(result.value["Accept"], "application/json")
+    }
+
+    func testCookieRedactionRemovesCookieValuesButKeepsAttributes() {
+        let result = WebSafetyRedactor.redactCookieHeader(
+            "session=abc123; theme=dark; Path=/; HttpOnly; SameSite=Lax"
+        )
+        XCTAssertTrue(result.redacted)
+        XCTAssertEqual(
+            result.value,
+            "session=<redacted>; theme=<redacted>; Path=/; HttpOnly; SameSite=Lax"
+        )
+    }
+
+    func testTextRedactionCoversCredentialURLsHeadersAndPairs() {
+        let text = """
+        GET https://example.com/callback?access_token=abc123&q=ok
+        Authorization: Bearer secret-token-value
+        api_key=plain-secret
+        """
+        let result = WebSafetyRedactor.redactText(text)
+        XCTAssertTrue(result.redacted)
+        XCTAssertFalse(result.value.contains("abc123"))
+        XCTAssertFalse(result.value.contains("secret-token-value"))
+        XCTAssertFalse(result.value.contains("plain-secret"))
+        XCTAssertTrue(result.value.contains("access_token=REDACTED"))
+        XCTAssertTrue(result.value.contains("Authorization: <redacted>"))
+        XCTAssertTrue(result.value.contains("api_key=REDACTED"))
+    }
+}

--- a/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/RedirectPolicyTests.swift
+++ b/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/RedirectPolicyTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import OsaurusToolSecurity
+
+final class RedirectPolicyTests: XCTestCase {
+    private func redirectPolicy(resolutions: [String: [String]] = [:]) -> RedirectPolicy {
+        RedirectPolicy(urlPolicy: URLPolicy { host in
+            resolutions[host] ?? ["93.184.216.34"]
+        })
+    }
+
+    func testRedirectTargetReRunsPolicyAndBlocksPrivateHop() {
+        assertRejectedRedirect(
+            from: "https://example.com/start",
+            to: "http://192.168.1.1/admin",
+            code: .ssrfBlocked
+        )
+    }
+
+    func testRedirectTargetBlocksMetadataEvenWithPrivateAccessAllowed() {
+        assertRejectedRedirect(
+            from: "https://example.com/start",
+            to: "http://169.254.169.254/latest/meta-data/",
+            code: .ssrfBlocked,
+            options: .init(allowPrivateNetwork: true)
+        )
+    }
+
+    func testSameOriginRedirectKeepsHeaders() throws {
+        let decision = try redirectPolicy().evaluate(
+            from: URL(string: "https://example.com/start")!,
+            to: URL(string: "https://example.com/next")!,
+            headers: ["Authorization": "Bearer abc", "Accept": "application/json"]
+        )
+        XCTAssertFalse(decision.strippedSensitiveHeaders)
+        XCTAssertEqual(decision.headers["Authorization"], "Bearer abc")
+        XCTAssertEqual(decision.headers["Accept"], "application/json")
+    }
+
+    func testCrossOriginRedirectStripsSensitiveHeaders() throws {
+        let decision = try redirectPolicy().evaluate(
+            from: URL(string: "https://example.com/start")!,
+            to: URL(string: "https://other.example/next")!,
+            headers: [
+                "Authorization": "Bearer abc",
+                "Cookie": "session=abc",
+                "X-Api-Key": "secret",
+                "Accept": "application/json",
+            ]
+        )
+        XCTAssertTrue(decision.strippedSensitiveHeaders)
+        XCTAssertNil(decision.headers["Authorization"])
+        XCTAssertNil(decision.headers["Cookie"])
+        XCTAssertNil(decision.headers["X-Api-Key"])
+        XCTAssertEqual(decision.headers["Accept"], "application/json")
+    }
+
+    func testHTTPSDowngradeStripsSensitiveHeaders() throws {
+        let decision = try redirectPolicy().evaluate(
+            from: URL(string: "https://example.com/start")!,
+            to: URL(string: "http://example.com/next")!,
+            headers: ["Authorization": "Bearer abc", "User-Agent": "Osaurus"]
+        )
+        XCTAssertTrue(decision.strippedSensitiveHeaders)
+        XCTAssertNil(decision.headers["Authorization"])
+        XCTAssertEqual(decision.headers["User-Agent"], "Osaurus")
+    }
+
+    private func assertRejectedRedirect(
+        from current: String,
+        to target: String,
+        code: WebSafetyErrorCode,
+        options: URLPolicyOptions = URLPolicyOptions(),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        do {
+            _ = try redirectPolicy().evaluate(
+                from: URL(string: current)!,
+                to: URL(string: target)!,
+                headers: ["Authorization": "Bearer abc"],
+                options: options
+            )
+            XCTFail("Expected redirect to \(target) to be rejected", file: file, line: line)
+        } catch let error as WebSafetyError {
+            XCTAssertEqual(error.code, code, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/URLPolicyTests.swift
+++ b/Shared/OsaurusToolSecurity/Tests/OsaurusToolSecurityTests/URLPolicyTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+
+@testable import OsaurusToolSecurity
+
+final class URLPolicyTests: XCTestCase {
+    private func policy(resolutions: [String: [String]] = [:]) -> URLPolicy {
+        URLPolicy { host in
+            resolutions[host] ?? ["93.184.216.34"]
+        }
+    }
+
+    func testAllowsPublicHTTPSURL() throws {
+        let decision = try policy().validate("https://example.com/path?q=search")
+        XCTAssertEqual(decision.host, "example.com")
+        XCTAssertEqual(decision.resolvedAddresses, ["93.184.216.34"])
+        XCTAssertTrue(decision.warnings.isEmpty)
+    }
+
+    func testRejectsUnsafeSchemesEvenWhenPrivateAccessIsAllowed() {
+        for rawURL in ["file:///etc/passwd", "data:text/plain,hello", "javascript:alert(1)"] {
+            assertRejected(rawURL, code: .unsafeScheme, options: .init(allowPrivateNetwork: true))
+        }
+    }
+
+    func testAboutBlankRequiresExplicitOptIn() throws {
+        assertRejected("about:blank", code: .unsafeScheme)
+
+        let decision = try policy().validate("about:blank", options: .init(allowAboutBlank: true))
+        XCTAssertTrue(decision.isAboutBlank)
+    }
+
+    func testRejectsUserInfoAsSecretInURL() {
+        assertRejected("https://user:pass@example.com/path", code: .secretInURL)
+        assertRejected("http://169.254.169.254@expected.com/", code: .secretInURL)
+        assertRejected("http://expected.com@169.254.169.254/", code: .secretInURL)
+    }
+
+    func testBlocksLocalhostAndPrivateIPv4ByDefault() {
+        assertRejected("http://localhost:8080/", code: .ssrfBlocked)
+        assertRejected("http://127.0.0.1/", code: .ssrfBlocked)
+        assertRejected("http://10.0.0.1/", code: .ssrfBlocked)
+        assertRejected("http://172.16.0.1/", code: .ssrfBlocked)
+        assertRejected("http://192.168.1.1/", code: .ssrfBlocked)
+        assertRejected("http://0.0.0.0/", code: .ssrfBlocked)
+    }
+
+    func testBlocksLocalAndInternalHostnamesByDefault() {
+        assertRejected("http://printer.local/", code: .ssrfBlocked)
+        assertRejected("http://service.internal./", code: .ssrfBlocked)
+        assertRejected("http://%6cocalhost/", code: .ssrfBlocked)
+        assertRejected("http://LOCALHOST/", code: .ssrfBlocked)
+    }
+
+    func testAllowsPrivateNetworkWhenExplicitlyEnabledExceptMetadata() throws {
+        let decision = try policy().validate(
+            "http://192.168.1.1/admin",
+            options: .init(allowPrivateNetwork: true)
+        )
+        XCTAssertEqual(decision.host, "192.168.1.1")
+    }
+
+    func testBlocksMetadataHostnamesEvenWhenPrivateAccessIsAllowed() {
+        let options = URLPolicyOptions(allowPrivateNetwork: true)
+        assertRejected("http://metadata.google.internal/", code: .ssrfBlocked, options: options)
+        assertRejected("http://metadata.amazonaws.com/", code: .ssrfBlocked, options: options)
+        assertRejected("http://instance-data.ec2.internal/", code: .ssrfBlocked, options: options)
+    }
+
+    func testBlocksMetadataIPv4EncodingsEvenWhenPrivateAccessIsAllowed() {
+        let options = URLPolicyOptions(allowPrivateNetwork: true)
+        assertRejected("http://169.254.169.254/", code: .ssrfBlocked, options: options)
+        assertRejected("http://2852039166/", code: .ssrfBlocked, options: options)
+        assertRejected("http://0xa9fea9fe/", code: .ssrfBlocked, options: options)
+        assertRejected("http://025177524776/", code: .ssrfBlocked, options: options)
+        assertRejected("http://169.254.43518/", code: .ssrfBlocked, options: options)
+        assertRejected("http://100.100.100.200/", code: .ssrfBlocked, options: options)
+    }
+
+    func testBlocksNonDottedLoopbackIPv4Forms() {
+        assertRejected("http://2130706433/", code: .ssrfBlocked)
+        assertRejected("http://0x7f000001/", code: .ssrfBlocked)
+        assertRejected("http://017700000001/", code: .ssrfBlocked)
+        assertRejected("http://127.1/", code: .ssrfBlocked)
+    }
+
+    func testBlocksIPv6LoopbackLinkLocalULAAndMetadataForms() {
+        assertRejected("http://[::1]/", code: .ssrfBlocked)
+        assertRejected("http://[fe80::1%25en0]/", code: .ssrfBlocked)
+        assertRejected("http://[fd12:3456::1]/", code: .ssrfBlocked)
+        assertRejected("http://[::ffff:169.254.169.254]/", code: .ssrfBlocked)
+        assertRejected("http://[64:ff9b::a9fe:a9fe]/", code: .ssrfBlocked)
+        assertRejected("http://[2002:a9fe:a9fe::1]/", code: .ssrfBlocked)
+        assertRejected("http://[2001:0000:0808:0808:0000:0000:5601:5601]/", code: .ssrfBlocked)
+    }
+
+    func testBlocksResolvedPrivateAddressesByDefault() {
+        let guarded = policy(resolutions: ["public.example": ["93.184.216.34", "192.168.1.10"]])
+        assertRejected("https://public.example/", code: .ssrfBlocked, policy: guarded)
+    }
+
+    func testBlocksHostnameWhenResolutionFailsClosed() {
+        let guarded = URLPolicy { _ in [] }
+        assertRejected("https://unresolved.example/", code: .ssrfBlocked, policy: guarded)
+    }
+
+    func testAllowsResolvedPrivateAddressWithPrivateAccessButStillBlocksResolvedMetadata() throws {
+        let guarded = policy(resolutions: [
+            "private.example": ["192.168.1.10"],
+            "metadata.example": ["169.254.169.254"],
+        ])
+
+        _ = try guarded.validate(
+            "https://private.example/",
+            options: .init(allowPrivateNetwork: true)
+        )
+        assertRejected(
+            "https://metadata.example/",
+            code: .ssrfBlocked,
+            options: .init(allowPrivateNetwork: true),
+            policy: guarded
+        )
+    }
+
+    func testSignedCloudQueryStringsAreRedactedButNotRejected() throws {
+        let decision = try policy().validate(
+            "https://storage.googleapis.com/bucket/object?X-Goog-Signature=abc123&X-Goog-Credential=issuer&q=benign"
+        )
+        XCTAssertTrue(decision.warnings.contains("credential-looking URL components were redacted"))
+        XCTAssertTrue(decision.redactedURL.contains("X-Goog-Signature=REDACTED"))
+        XCTAssertTrue(decision.redactedURL.contains("X-Goog-Credential=REDACTED"))
+        XCTAssertTrue(decision.redactedURL.contains("q=benign"))
+    }
+
+    func testPercentDecodedSecretPrefixesAreRedactedButNotRejected() throws {
+        let decision = try policy().validate("https://example.com/callback?next=sk-%255Fsecret-value")
+        XCTAssertTrue(decision.redactedURL.contains("next=REDACTED"))
+        XCTAssertTrue(decision.warnings.contains("credential-looking URL components were redacted"))
+    }
+
+    private func assertRejected(
+        _ rawURL: String,
+        code: WebSafetyErrorCode,
+        options: URLPolicyOptions = URLPolicyOptions(),
+        policy: URLPolicy? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let guarded = policy ?? self.policy()
+        do {
+            _ = try guarded.validate(rawURL, options: options)
+            XCTFail("Expected \(rawURL) to be rejected", file: file, line: line)
+        } catch let error as WebSafetyError {
+            XCTAssertEqual(error.code, code, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/docs/BROWSING_CAPABILITY_EXECUTION_PLAN_2026_07_06.md
+++ b/docs/BROWSING_CAPABILITY_EXECUTION_PLAN_2026_07_06.md
@@ -1,0 +1,738 @@
+# Osaurus Browsing Capability Execution Plan
+
+Date: 2026-07-06  
+Repository: `osaurus-ai/osaurus-tools`  
+Base branch: `master`
+
+Primary goal: make Osaurus browsing tools safe, readable, testable, and useful for real agent browsing workflows. This plan favors reviewable functional PRs over one oversized security PR, but every PR below must still deliver a real behavior improvement.
+
+## Strategic Direction From External Harness Learnings
+
+The attached reference-harness analysis reinforces the product direction without
+making another harness the target architecture:
+
+- Osaurus already has a broad local browser/search/fetch surface: WebKit
+  automation, per-agent profiles, login helper, network/console/cookie tools,
+  batched browser actions, search provider breadth, and one-shot
+  `search_and_extract`.
+- The highest-value gaps are not more provider backends. They are browser URL
+  safety, readable authenticated/JS-rendered pages, budgeted outputs, local
+  visual grounding, and an optional connection to a user's own Chrome-class
+  browser.
+- Osaurus should incorporate the useful engineering lessons through
+  Osaurus-native mechanisms: WebKit safety, `browser_read`, deterministic eval
+  evidence, local VLM vision, and later CDP attach to the user's own browser.
+  Cloud browser or premium extraction backends remain optional plugin lanes,
+  not the core plan.
+- `browser_read` is the major user-visible capability jump after P0 safety. It
+  lets agents read logged-in or JS-rendered pages without arbitrary
+  `browser_execute_script` workarounds or session-losing `fetch_html` calls.
+- CDP/Chrome attach is a later engine-breadth lane. It should not delay the
+  WebKit safety and readable-page work.
+
+## Current State
+
+The browsing surface is split across three native plugin packages:
+
+- `tools/browser`: WebKit browser automation with persistent per-agent sessions, login helper, element refs, screenshots, console/network inspection, dialogs, cookies, viewport, user-agent, locks, and reset.
+- `tools/fetch`: HTTP fetch/download with initial SSRF guard, response size caps, redirects, and lightweight HTML extraction.
+- `tools/search`: web/news/image search across paid and free providers plus `search_and_extract`.
+
+GitHub state:
+
+- `osaurus-tools` default branch is `master`.
+- Open PR #162, from another author, adds a Keenable search backend and is currently behind `master`.
+- Do not duplicate #162. Search work here avoids provider-table, secret-list, default-priority, and Keenable-specific changes unless explicitly helping that PR.
+- Open issue #165 asks about a community web-backend plugin. This plan keeps first-party browsing local-first and leaves cloud/community extraction backends as optional later work.
+
+Confirmed code findings:
+
+- Browser navigation has no URL policy/SSRF guard. `browser_navigate`, click/form/script navigations, and `browser_open_login` can reach private/internal hosts.
+- Fetch checks only the initial URL. Redirect targets are followed without a second SSRF check, and credential headers are not stripped on cross-origin redirects.
+- `allow_private` in fetch currently bypasses scheme policy too early. `file:` can pass when private access is allowed.
+- `search_and_extract` has its own URLSession extraction path and no SSRF/private-network guard.
+- Native plugin outputs should not rely on central secret scrubbing. The host normalizes/caps tool results, but the native plugin path does not apply a universal scrubber.
+- Browser snapshots can leak input values, cookies, console/network URLs, dialog text, and script results.
+- Browser snapshots are interaction-oriented, not reading-oriented. They expose refs and small text excerpts, but no rendered-page content extraction.
+- Browser snapshot filtering likely has a JS variable bug: the filter condition references `el` inside a `TreeWalker` callback where the current node is `node`.
+- Host plugin API supports inference, but the browser plugin currently mirrors only config/log strongly. Any vision/task-aware compaction work needs explicit host API mirror expansion.
+- Plugins do not have a documented arbitrary file-write host API. Durable state should use plugin SQLite, and large user-visible artifacts need a deliberate artifact path or cursor/pagination design.
+- Current evals prove browser tool discovery, not end-to-end browsing. Browsing evals must explicitly bootstrap native plugins until the eval bootstrap mismatch is fixed.
+
+Attached-plan confirmations:
+
+- Browser plugin URL policy is the P0 security gap because fetch has partial
+  SSRF protection but live WebKit navigation does not.
+- Browser-readable page content is the highest capability ROI after security.
+- Output budget/spill must use cursor pagination first unless a host-readable
+  plugin artifact path is confirmed.
+- CDP, browser vision, popups/downloads, PDF extraction, and session hygiene are
+  valuable follow-up lanes, but they should not preempt P0 safety plus
+  `browser_read`.
+
+## Wave 0 Decisions
+
+Wave 0 is mandatory before implementation. These are design decisions, not vague risks.
+
+### Shared Security Code Mechanism
+
+Decision target:
+
+- Prefer a source target statically compiled into each plugin dylib, or a small script-synced vendored source file, over a separately packaged shared dylib.
+- Do not place a plugin-like `Package.swift` under `tools/common`; release scripts treat `tools/*/Package.swift` as plugin packages.
+- If a root-level Swift package is used, prove `scripts/build-tool.sh browser`, `scripts/build-tool.sh fetch`, and `scripts/build-tool.sh search` still produce one plugin dylib per tool and do not require shipping an extra shared dylib.
+
+Acceptance checks:
+
+- Package graph inspection shows no extra dynamic library artifact for shared security code.
+- `scripts/build-tool.sh <tool> --version <test-version>` still stages one plugin dylib plus docs/assets.
+- `scripts/regenerate-catalogs.py --check --tool <tool>` still works.
+- If script-synced vendored sources are selected, add a drift check such as `scripts/check-websafety-sync.sh` and wire it into validation. Without a drift check, script-synced vendoring is rejected for security code.
+
+### Browser Test Fixture Strategy
+
+Problem:
+
+- Existing browser tests use `file://` fixtures.
+- New production URL policy must block `file:`.
+- Browser security/eval tests need deterministic local pages, but loopback should be blocked in production by default.
+
+Decision target:
+
+- Use a production-inert test strategy. Acceptable options:
+  - an injected policy resolver in tests, with no production environment-variable bypass;
+  - a local HTTP fixture server only when a test-only policy context explicitly allows loopback;
+  - `loadHTMLString` for unit-style DOM tests that do not exercise navigation policy.
+- Do not add a production `file://` or loopback allowance just to make tests pass.
+
+Acceptance checks:
+
+- Production policy blocks `file:`, loopback, and private ranges by default.
+- Tests can prove blocked production behavior and allowed fixture behavior separately.
+- Any test-only bypass is unavailable in release/plugin runtime.
+
+### Main App Worktree For Evals
+
+The main Osaurus app checkout is dirty. Browsing eval work must use a fresh worktree, for example:
+
+- `/Users/mmeding/Developer/Claude/Projects/osaurus-worktrees/browse-eval-evidence`
+
+Acceptance checks:
+
+- No edits are made in the dirty app root checkout.
+- The eval PR records which `osaurus-tools` plugin build or source SHA it tested.
+
+### Wave 0 Decision Artifact
+
+Wave 0 must leave a committed or PR-local decision artifact before adoption PRs proceed. The artifact records:
+
+- chosen shared-code mechanism;
+- exact test fixture strategy;
+- package/build proof commands and outcomes;
+- cross-repo eval worktree path;
+- whether the P0 wave uses unit/live WebKit tests only or waits for browsing evals.
+
+## Execution Principles
+
+- Ship meaningful functional PRs, not one-line slices.
+- Start every new branch from fresh `origin/master`.
+- Use one isolated worktree per independent lane.
+- Keep branch scopes disjoint unless the controller intentionally serializes a shared dependency.
+- Treat security, credential handling, cookies, browsing history, network targets, downloads, screenshots, and cross-origin redirects as security-sensitive.
+- Do not claim browser functionality works from source inspection only. Require unit tests and, where feasible, live WebKit proof behind explicit local test gates.
+- Do not mark a PR ready until local validation passes, GitHub checks are green, and merge state is clean.
+- Keep public PR wording human-readable.
+
+## PR 1: Add Shared Web Safety Core
+
+Branch: `browse/web-safety-core`  
+Priority: P0  
+Parallelization: starts first; fetch/search/browser adoption branches rebase onto it.
+
+Owned scope:
+
+- Shared source location selected in Wave 0.
+- Shared tests.
+- Build/package scripts only if necessary to support static/shared source adoption.
+- Documentation explaining the policy contract.
+
+Feature:
+
+- Add reusable URL policy, metadata-endpoint detection, credential URL detection, URL redaction, header redaction, cookie redaction, and output redaction helpers for first-party web tools.
+
+Functional requirements:
+
+- Accept only `http` and `https` for network requests.
+- Allow `about:blank` only where explicitly needed by the browser login helper.
+- Reject URL userinfo as `SECRET_IN_URL`.
+- Treat credential-looking query strings as redaction targets by default, not necessarily hard request blockers, because signed cloud URLs are legitimate. Hard-block only clearly embedded secrets such as userinfo or raw secret tokens in unsafe contexts.
+- Block private, loopback, link-local, multicast, reserved, `.local`, `.internal`, and cloud metadata endpoints by default.
+- Metadata IPs and hostnames remain blocked even when private access is allowed, including common encodings of `169.254.169.254`.
+- Validate scheme before any `allow_private` bypass.
+- Re-run DNS and policy checks for every redirect or navigation decision.
+- Define accepted residual risk for DNS rebinding if the implementation cannot pin resolved IPs through URLSession/WKWebView.
+- Add a shared download path-jail validator so later fetch/browser download work does not duplicate path policy.
+- Provide a safe GET helper or redirect-policy primitive that fetch and search extraction can share for redirect re-validation and byte limits.
+- Provide stable error codes:
+  - `SSRF_BLOCKED`
+  - `SECRET_IN_URL`
+  - `UNSAFE_SCHEME`
+
+Tests:
+
+- Public HTTPS allowed.
+- `file:`, `data:`, and `javascript:` rejected even when private access is allowed.
+- Localhost and RFC1918 blocked by default.
+- Metadata IP/host blocked even when private access is allowed.
+- URL userinfo rejected.
+- Signed-cloud-style query strings are redacted in output without being automatically rejected.
+- OAuth/token-bearing URL fragments are redacted.
+- Percent-decoded secret prefixes are redacted or rejected per policy.
+- IPv6 loopback/link-local/ULA rejected.
+- Header redaction covers `Authorization`, `Cookie`, `Set-Cookie`, proxy auth, and common token headers.
+- Download path validator rejects absolute paths, parent traversal, hidden/tilde paths, path separators, and paths outside the chosen download/artifact directory.
+
+Validation:
+
+- Shared tests.
+- Package artifact proof from Wave 0.
+- `git diff --check`.
+
+## PR 2: Fix Browser Snapshot Filters And Test Harness Foundation
+
+Branch: `browse/snapshot-filter-foundation`  
+Priority: P0/P1  
+Parallelization: can start immediately after Wave 0 decisions; keep max one open browser PR at a time unless `Plugin.swift` is split.
+
+Owned scope:
+
+- `tools/browser/Sources/OsaurusBrowser/Plugin.swift`
+- `tools/browser/Tests/OsaurusBrowserTests/*`
+- test fixtures/helpers only as required by the production-inert fixture strategy.
+
+Feature:
+
+- Fix the confirmed snapshot filter bug and establish browser test helper patterns needed by later security work.
+
+Functional requirements:
+
+- `inputs`, `buttons`, `links`, and `forms` filters operate on the current DOM node.
+- Add regression tests that fail under the old JS.
+- Keep output format compatible.
+- Add or document test helpers for production-blocked navigation versus fixture-allowed navigation, without adding any production runtime bypass.
+
+Tests:
+
+- Filter fixtures for each filter mode.
+- Hidden elements remain excluded when `visible_only=true`.
+- Test-harness helper proves production policy and fixture policy are separate when policy code is present.
+
+Validation:
+
+- `swift test --package-path tools/browser`
+- `git diff --check`
+
+## PR 3: Harden Fetch Redirects And Outputs
+
+Branch: `browse/fetch-url-safety`  
+Priority: P0  
+Parallelization: depends on PR 1; can run independently of browser once PR 1 lands or is stable.
+
+Owned scope:
+
+- `tools/fetch/Package.swift`
+- `tools/fetch/Sources/OsaurusFetch/Plugin.swift`
+- `tools/fetch/Tests/OsaurusFetchTests/*`
+- `tools/fetch/SKILL.md`
+- `tools/fetch/CHANGELOG.md`
+
+Feature:
+
+- Adopt shared web safety in `osaurus.fetch`.
+- Close redirect SSRF and credential-forwarding gaps.
+- Redact sensitive response fields.
+
+Functional requirements:
+
+- Initial URL uses shared policy.
+- Every redirect target re-runs policy before following.
+- Redirect header stripping is based on scheme, host, and port.
+- Strip sensitive headers on cross-origin redirects and on HTTPS-to-HTTP downgrade.
+- Preserve `allow_private` only for documented trusted local/private use, never for unsafe schemes or metadata endpoints.
+- Redact:
+  - `final_url`
+  - `redirect_chain`
+  - sensitive response headers
+  - credential-like URLs in body snippets where feasible
+- Add warnings when redaction occurs.
+
+Tests:
+
+- Redirect to private host blocked.
+- Redirect to metadata endpoint blocked even with private access allowed.
+- Cross-origin redirect strips auth/cookie headers.
+- HTTPS-to-HTTP redirect strips auth/cookie headers.
+- `file:` rejected with private access allowed.
+- Sensitive headers redacted.
+- Token query strings redacted in final URL and redirect chain.
+
+Validation:
+
+- `swift test --package-path tools/fetch`
+- `python3 scripts/validate.py` if manifest/catalog changes.
+- `scripts/regenerate-catalogs.py --check --tool fetch`
+- `git diff --check`
+
+## PR 4: Harden Search Extraction Safety
+
+Branch: `browse/search-extraction-safety`  
+Priority: P0  
+Parallelization: depends on PR 1; avoids PR #162 provider backend files where possible.
+
+Owned scope:
+
+- `tools/search/Package.swift`
+- `tools/search/Sources/OsaurusSearch/Plugin.swift`
+- `tools/search/Tests/OsaurusSearchTests/*`
+- `tools/search/SKILL.md`
+- `tools/search/CHANGELOG.md`
+
+Feature:
+
+- Put `search_and_extract` inside the same URL safety perimeter as fetch and browser.
+
+Functional requirements:
+
+- Apply shared URL policy to every extracted search result URL.
+- Re-validate every extraction redirect target.
+- Apply the shared response byte cap / safe GET primitive rather than unbounded `URLSession.shared`.
+- Add a `max_bytes` cap or equivalent extraction size cap.
+- Preserve provider selection, provider priority, and Keenable PR #162 scope.
+- Report per-result skipped/error states for blocked or unsupported extraction targets.
+- Do not silently treat PDFs/binary pages as failed HTML; return typed skipped/unsupported states until PDF extraction lands.
+- Redact credential-like URLs in result/extraction outputs.
+
+Tests:
+
+- `search_and_extract` blocks private/internal result URLs.
+- `search_and_extract` blocks metadata endpoints.
+- Signed URL query parameters are redacted in output.
+- Binary/PDF-like result is skipped with explicit unsupported state.
+- Provider priority and valid-provider sets do not change.
+
+PR #162 conflict handling:
+
+- PR #162 edits the same search implementation and changelog files. If #162 is still open when this lane starts, keep this PR draft until rebased on top of #162 or explicitly state that the branch will offer the #162 author a rebase. Do not silently compete for the same version/changelog entry.
+
+Validation:
+
+- `swift test --package-path tools/search`
+- `python3 scripts/validate.py` if manifest/catalog changes.
+- `scripts/regenerate-catalogs.py --check --tool search`
+- `git diff --check`
+
+## PR 5: Harden Browser Navigation Policy
+
+Branch: `browse/browser-navigation-safety`  
+Priority: P0  
+Parallelization: depends on PR 1; serialize before browser output/readability PRs that touch the same monolithic plugin file.
+
+Owned scope:
+
+- `tools/browser/Package.swift`
+- `tools/browser/Sources/OsaurusBrowser/Plugin.swift`
+- `tools/browser/Sources/OsaurusBrowser/LoginWindow.swift`
+- `tools/browser/Tests/OsaurusBrowserTests/*`
+- `tools/browser/SKILL.md`
+- `tools/browser/CHANGELOG.md`
+
+Feature:
+
+- Adopt shared web safety in the WebKit browser plugin.
+- Block unsafe main-frame browser navigation before loading and during redirects/script-driven navigation.
+
+Functional requirements:
+
+- Validate direct `browser_navigate`.
+- Validate `browser_open_login` initial URL and helper-window address-bar loads.
+- Add `WKNavigationDelegate.decidePolicyFor` checks for every main-frame navigation.
+- Validate iframe navigations as well as top-level navigations where WebKit exposes them.
+- Add a mandatory minimum `WKContentRuleList` or equivalent blocking layer for literal metadata, loopback, RFC1918, link-local, and private-range subresource URLs when WebKit supports it.
+- Document residual risk for DNS-named internal subresources if the implementation cannot resolve them before load.
+- Record last blocked navigation and surface it in subsequent snapshots.
+- Preserve `about:blank` only for login helper blank start.
+- Keep local/private navigation opt-in and explicit; never allow metadata endpoints.
+- Define browser private-access opt-in precisely:
+  - per-call parameter, session setting, or both;
+  - inheritance rule for redirects and script-driven navigation after an allowed private navigation;
+  - user-facing error hint when local/private browsing is blocked by default.
+
+Tests:
+
+- Unsafe direct navigation returns typed failure.
+- Script-driven `location.href` to private host is blocked.
+- Redirect/meta-refresh private target is blocked where testable.
+- Literal private subresource request is blocked or appears in an explicit residual-risk test if WebKit cannot enforce it.
+- Login helper rejects unsafe initial URL.
+- Test fixture strategy from Wave 0 is used without production bypass.
+- Optional live WebKit proof.
+
+Validation:
+
+- `swift test --package-path tools/browser`
+- Optional live WebKit test command where supported.
+- `python3 scripts/validate.py` if manifest/catalog changes.
+- `scripts/regenerate-catalogs.py --check --tool browser`
+- `git diff --check`
+
+## PR 6: Redact Browser Outputs And Guard Credential Entry
+
+Branch: `browse/browser-output-redaction`  
+Priority: P0/P1  
+Parallelization: depends on PR 1 and should serialize after PR 4 unless `Plugin.swift` is split.
+
+Owned scope:
+
+- `tools/browser/Sources/OsaurusBrowser/Plugin.swift`
+- `tools/browser/Tests/OsaurusBrowserTests/*`
+- `tools/browser/SKILL.md`
+- `tools/browser/CHANGELOG.md`
+
+Feature:
+
+- Prevent browser tool outputs from leaking secrets into the agent context.
+
+Functional requirements:
+
+- Redact password and credential field values in snapshots.
+- Add reusable internal browser sanitizer APIs so `browser_read` can reuse exactly the same redaction path later.
+- Redact cookie values from `browser_cookies get`.
+- Redact console messages, network request URLs, dialog text, script results, final login URLs, and snapshot URLs where credential-like values appear.
+- Headless `browser_type` and `browser_do` reject typing into password fields and return a login-helper hint.
+- `browser_execute_script` result redaction is best-effort and clearly documented.
+- Screenshot output remains a file path; do not claim pixel-level redaction. Add guidance that screenshots can contain visible page secrets.
+
+Tests:
+
+- Password input value does not appear in formatted snapshots.
+- Cookie values are redacted.
+- Console/network buffers redact token-bearing URLs.
+- Dialog text redaction works.
+- Script result redaction works for representative token strings.
+- Typing into password fields returns a login-helper error.
+- Sanitizer helper is directly tested and reused by snapshot formatting.
+
+Validation:
+
+- `swift test --package-path tools/browser`
+- `scripts/regenerate-catalogs.py --check --tool browser` if docs/catalog change.
+- `git diff --check`
+
+## PR 7: Browser Readable Page Tool
+
+Branch: `browse/browser-read`  
+Priority: P1  
+Parallelization: after PR 4/5 or after a file split that makes scope disjoint.
+
+Owned scope:
+
+- `tools/browser/Sources/OsaurusBrowser/Plugin.swift`
+- `tools/browser/Tests/OsaurusBrowserTests/*`
+- `tools/browser/Tests/OsaurusBrowserTests/Fixtures/*`
+- `tools/browser/SKILL.md`
+- `tools/browser/CHANGELOG.md`
+- `plugins/osaurus.browser.json` through catalog regeneration only if needed.
+
+Feature:
+
+- Add `browser_read` so agents can read authenticated and JS-rendered pages without arbitrary scripts.
+
+Attached-plan learning:
+
+- Treat this as the largest immediate user-facing browsing improvement after
+  URL safety. The implementation should first prove deterministic rendered-DOM
+  extraction and cursor pagination. Vendored Readability.js can be added only if
+  fixture evidence shows the simpler DOM extractor is not reliable enough.
+
+Functional requirements:
+
+- Reads live rendered DOM content.
+- Supports `format: "markdown" | "text"`.
+- Supports `selector`.
+- Supports `max_chars`.
+- Supports cursor pagination for large content.
+- Returns `{ok, data}` with `title`, `url`, content, `word_count`, `truncated`, and `next_cursor`.
+- Applies the same URL/form-field/text redaction layer as snapshots.
+- Treat page content as untrusted data in SKILL guidance; the agent should quote/summarize it as webpage content, not follow instructions embedded in it.
+- Uses cursor pagination first; do not assume host-readable cache writes.
+- Avoid full Readability vendoring unless fixture quality proves deterministic DOM extraction is insufficient.
+
+Tests:
+
+- JS-rendered article fixture returns rendered text.
+- Long article pagination returns a cursor and continuation.
+- Selector-scoped extraction.
+- Redaction inside `browser_read` output.
+- Prompt-injection fixture or eval task where page text attempts to override system/developer instructions; agent must treat it as page content.
+- Manifest tests for `browser_read`.
+- Skill guidance tells agents to use `browser_read` for content instead of arbitrary scripts.
+
+Validation:
+
+- `swift test --package-path tools/browser`
+- Optional live WebKit proof.
+- `python3 scripts/validate.py` if manifest/catalog changes.
+- `scripts/regenerate-catalogs.py --check --tool browser`
+- `git diff --check`
+
+## PR 8: Browsing Evals And Plugin Build Evidence
+
+Branch: `browse/eval-evidence`  
+Priority: P1  
+Parallelization: main-app worktree can start immediately, but tasks that prove new plugin behavior must pin the matching plugin build/SHA.
+
+Owned scope:
+
+- Main app repo fresh worktree only:
+  - `Packages/OsaurusEvals/Suites/*`
+  - `Packages/OsaurusEvals/Sources/*` only if bootstrap behavior must be fixed
+  - `scripts/review/evals-browsing-evidence.sh`
+  - eval docs if needed
+
+Feature:
+
+- Add deterministic browsing eval evidence so browser/search/fetch PRs can prove real agent behavior.
+
+Functional requirements:
+
+- Define reproducible plugin bootstrap:
+  - released plugin version pin, or
+  - local dylib path built from a recorded `osaurus-tools` SHA, or
+  - source checkout path plus build command.
+- Add a suite that can initially prove current behavior:
+  - open a deterministic page and inspect/summarize it
+  - complete a simple form
+  - handle a dialog
+- Add security evals only when the matching security PR is available:
+  - unsafe URL blocked
+  - redirect/private target blocked
+  - cookie/password/token value does not appear in transcript
+  - page-content prompt injection remains quoted/summarized as untrusted content
+- Record exact tool calls, arguments, failures, and grounded final answers.
+- Explicitly bootstrap native browser plugin until automatic bootstrap is fixed.
+- Use a browsing-specific evidence script name so it cannot be confused with
+  broader local/frontier PR eval evidence workflows.
+- The current helper starts a loopback fixture server. Future browser URL
+  policy adoption must keep that allowance eval-only and continue blocking
+  loopback in production by default.
+
+Tests:
+
+- Eval suite fixture schema tests.
+- Runner smoke test if bootstrap changes.
+- `swift test --package-path Packages/OsaurusEvals` in the main app worktree.
+
+Validation:
+
+- Main app worktree only:
+  - `swift test --package-path Packages/OsaurusEvals`
+  - focused eval evidence CLI with explicit plugin bootstrap
+- `git diff --check`
+
+Risks:
+
+- This is cross-repo. It should not block P0 code fixes, but it should become the evidence gate for later browser tool/schema changes.
+- P0 security PRs may merge on unit tests plus live WebKit proof where available. The security milestone is not complete until PR 8 or a fast-follow eval slice proves SSRF/redaction behavior against pinned plugin builds.
+
+## PR 9: Fetch PDF And Download Extraction
+
+Branch: `browse/fetch-pdf-extraction`  
+Priority: P1/P2  
+Parallelization: after PR 2; serialize after search/fetch extraction safety if both touch fetch internals.
+
+Owned scope:
+
+- `tools/fetch/Sources/OsaurusFetch/Plugin.swift`
+- `tools/fetch/Tests/OsaurusFetchTests/*`
+- `tools/fetch/SKILL.md`
+- `tools/fetch/CHANGELOG.md`
+
+Feature:
+
+- Make PDF and non-HTML fetch behavior explicit and useful.
+
+Functional requirements:
+
+- Detect PDF by content type and/or magic bytes.
+- Add either:
+  - `fetch_pdf` with PDFKit extraction, or
+  - `fetch_html` typed `UNSUPPORTED_CONTENT_TYPE` with a clear `download` hint if PDFKit extraction is not reliable.
+- Preserve `download` path jail.
+- Reuse shared download path validator if one is introduced; do not reimplement independently for browser downloads later.
+- Include final URL, byte count, truncation, and extraction warnings.
+
+Tests:
+
+- Minimal PDF fixture.
+- PDF text extraction or explicit unsupported response.
+- Binary non-PDF content returns typed unsupported.
+- Download target remains jailed under `~/Downloads`.
+
+Validation:
+
+- `swift test --package-path tools/fetch`
+- `python3 scripts/validate.py` if manifest/catalog changes.
+- `scripts/regenerate-catalogs.py --check --tool fetch`
+- `git diff --check`
+
+## PR 10: Browser Popups, Downloads, And Session Hygiene
+
+Branch: `browse/browser-robustness`  
+Priority: P2  
+Parallelization: after PR 4/5/7, unless a preliminary file split makes scopes disjoint.
+
+Owned scope:
+
+- `tools/browser/Sources/OsaurusBrowser/Plugin.swift`
+- `tools/browser/Sources/OsaurusBrowser/SessionManager.swift`
+- `tools/browser/Sources/OsaurusBrowser/LoginWindow.swift`
+- `tools/browser/Tests/OsaurusBrowserTests/*`
+- browser docs/changelog.
+
+Feature:
+
+- Improve browser reliability on real sites that open new windows, download files, or keep sessions alive too long.
+
+Functional requirements:
+
+- Implement `WKUIDelegate.createWebViewWith` handling.
+- Default policy: same-view navigation for `target=_blank`, with a clear snapshot note.
+- Add tab list only if same-view behavior is insufficient.
+- Add browser download handling via `WKDownloadDelegate` where available.
+- Save downloads through the same path-jail policy as fetch.
+- Apply shared URL policy to download-triggering navigations and `WKDownload` URLs before saving.
+- Add idle session eviction with configurable timeout.
+- Clear `LoginWindow` associated-object retention after close to avoid leaks.
+
+Tests:
+
+- `target=_blank` fixture no longer no-ops.
+- Download fixture saves under allowed directory or returns typed unsupported.
+- Session idle eviction invalidates refs with clear error/hint.
+- Login window retention cleanup unit proof where possible.
+
+Validation:
+
+- `swift test --package-path tools/browser`
+- Optional live WebKit proof.
+- catalog check for browser if manifest changes
+- `git diff --check`
+
+## Deferred Lanes
+
+These remain valuable but should not distract from P0 safety and readability:
+
+- Browser vision and visual grounding.
+- CDP client foundation.
+- Chrome/Brave/Edge attach engine. This should connect to the user's own
+  locally launched or debug-port browser to improve engine breadth and
+  site-compatibility while staying local-first, not as an external hosted
+  browsing dependency.
+- Browser vision and annotated screenshot grounding. Reuse host inference/local
+  VLM support only after the exact plugin host inference API is confirmed.
+- Search diagnostics and optional extract backend extension point.
+
+## Open Questions From Attached Plan
+
+- Confirm the exact plugin host inference API before task-aware compaction or
+  `browser_vision`.
+- Confirm whether native plugins can write host-readable artifacts under
+  `~/.osaurus/cache` before choosing spill-to-disk over cursor pagination.
+- Confirm whether the main app centrally scrubs native plugin output envelopes.
+  Until proven, browser/fetch/search must scrub before returning tool results.
+- Confirm packaging behavior for each adoption PR: shared safety must remain
+  statically linked into each tool dylib and must not introduce an extra shared
+  runtime dylib.
+
+Each deferred lane should become its own feature plan after the first ten PRs are either merged or intentionally deferred.
+
+## Parallelization Matrix
+
+Can start immediately:
+
+- PR 1 shared web safety core.
+- PR 2 snapshot filter/test harness foundation, if controller keeps only one browser PR open at a time.
+- PR 8 eval harness work in a fresh main-app worktree, limited to bootstrap scaffolding and current-behavior tasks.
+
+Starts after PR 1:
+
+- PR 3 fetch URL safety.
+- PR 4 search extraction safety.
+- PR 5 browser navigation safety.
+
+Browser lanes that should serialize unless the monolithic browser file is split:
+
+- PR 2 snapshot filter/test harness foundation.
+- PR 5 browser navigation safety.
+- PR 6 browser output redaction.
+- PR 7 browser read.
+- PR 10 robustness.
+
+Fetch/search lanes:
+
+- PR 3 and PR 4 can run in parallel after PR 1 because they own different tool packages, subject to PR #162 conflict handling for search.
+- PR 9 should serialize after PR 3 and after any fetch-touching part of PR 4.
+
+Must remain serialized:
+
+- Shared security helper changes.
+- Browser manifest/SKILL/catalog updates.
+- Search provider-table edits because of PR #162.
+- Main-app eval bootstrap changes in the fresh main-app worktree.
+
+## Review And Validation Gates
+
+Every PR:
+
+- Local focused tests.
+- `git diff --check`.
+- Relevant catalog check.
+- `python3 scripts/validate.py` when manifests/catalogs change.
+- Human-readable PR body with scope, tests, security/eval evidence, and known risks.
+
+Security-sensitive PRs:
+
+- Explicit redaction tests.
+- Unsafe-target negative tests.
+- No credential leakage in output fixtures.
+- No hidden bypasses for `allow_private`.
+- Explicit breaking-change note when `allow_private` semantics change.
+- Explicit migration note when default private/loopback blocking changes local-first workflows.
+
+Browser behavior PRs:
+
+- Browser unit tests.
+- Live WebKit smoke when the environment supports it.
+- Browsing eval evidence once PR 8 exists.
+
+Agent-loop or tool-schema PRs:
+
+- Browsing eval evidence with plugin bootstrap.
+- Local/frontier eval evidence only where model behavior or agent-loop behavior changes.
+
+Second-opinion review:
+
+- Run a high-effort external plan review before execution.
+- Run code review after final diffs and local validation.
+- If external reviewers are unavailable, record unavailability and continue with implementation and local validation.
+- For P0 security PRs, second-opinion review is required unless the service is unavailable after retry; if unavailable, the PR must say local tests and maintainer review cover the gate.
+
+## First Execution Slice
+
+Start with PR 1, PR 2, and PR 8 scaffolding in parallel:
+
+- PR 1 makes shared policy/redaction decisions reviewable before tool adoption.
+- PR 2 fixes a confirmed browser bug and prepares the test harness needed by browser security work.
+- PR 8 can prepare plugin bootstrap and current-behavior browsing tasks without depending on new plugin behavior.
+
+After PR 1 stabilizes, run PR 3 and PR 4 in parallel. Then serialize browser PRs through PR 5, PR 6, and PR 7 unless a file split removes overlap.

--- a/tools/browser/Package.swift
+++ b/tools/browser/Package.swift
@@ -7,9 +7,13 @@ let package = Package(
     products: [
         .library(name: "OsaurusBrowser", type: .dynamic, targets: ["OsaurusBrowser"])
     ],
+    dependencies: [
+        .package(path: "../../Shared/OsaurusToolSecurity")
+    ],
     targets: [
         .target(
             name: "OsaurusBrowser",
+            dependencies: ["OsaurusToolSecurity"],
             path: "Sources/OsaurusBrowser",
             linkerSettings: [
                 .linkedFramework("WebKit"),
@@ -18,7 +22,7 @@ let package = Package(
         ),
         .testTarget(
             name: "OsaurusBrowserTests",
-            dependencies: ["OsaurusBrowser"],
+            dependencies: ["OsaurusBrowser", "OsaurusToolSecurity"],
             path: "Tests/OsaurusBrowserTests",
             resources: [.copy("Fixtures")]
         ),

--- a/tools/browser/Sources/OsaurusBrowser/LoginWindow.swift
+++ b/tools/browser/Sources/OsaurusBrowser/LoginWindow.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import OsaurusToolSecurity
 import WebKit
 
 /// Visible login window that lets the user sign in to a site using the same
@@ -132,7 +133,7 @@ final class LoginWindow: NSObject, NSWindowDelegate, WKNavigationDelegate {
         self.window = win
 
         if let url = initialURL {
-            webView.load(URLRequest(url: url))
+            loadAfterPolicyValidation(url)
         } else {
             webView.loadHTMLString(
                 """
@@ -177,10 +178,31 @@ final class LoginWindow: NSObject, NSWindowDelegate, WKNavigationDelegate {
                 + (raw.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? raw)
         }
         guard let url = URL(string: normalized) else { return }
-        webView.load(URLRequest(url: url))
+        loadAfterPolicyValidation(url)
     }
 
     // MARK: - WKNavigationDelegate
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let targetURL = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        switch validateBrowserNavigationURL(targetURL, resolveHostnames: false) {
+        case .success:
+            decisionHandler(.allow)
+        case .failure(let failure):
+            decisionHandler(.cancel)
+            DispatchQueue.main.async { [weak self] in
+                self?.renderBlockedNavigation(failure.message)
+            }
+        }
+    }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         updateNavButtons()
@@ -222,5 +244,42 @@ final class LoginWindow: NSObject, NSWindowDelegate, WKNavigationDelegate {
         let cont = continuation
         continuation = nil
         cont?.resume(returning: result)
+    }
+
+    private func renderBlockedNavigation(_ message: String) {
+        webView.loadHTMLString(
+            """
+            <html><body style="font-family:-apple-system;padding:40px;color:#333;">
+            <h2>Navigation blocked</h2>
+            <p>\(Self.escapeHTML(message))</p>
+            </body></html>
+            """,
+            baseURL: nil
+        )
+    }
+
+    private func loadAfterPolicyValidation(_ url: URL) {
+        let rawURL = url.absoluteString
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let validation = validateBrowserNavigationURL(rawURL, resolveHostnames: true)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch validation {
+                case .success(let decision):
+                    self.webView.load(URLRequest(url: decision.url))
+                case .failure(let failure):
+                    self.renderBlockedNavigation(failure.message)
+                }
+            }
+        }
+    }
+
+    private static func escapeHTML(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }

--- a/tools/browser/Sources/OsaurusBrowser/Plugin.swift
+++ b/tools/browser/Sources/OsaurusBrowser/Plugin.swift
@@ -1,6 +1,55 @@
 import AppKit
 import Foundation
+import OsaurusToolSecurity
 import WebKit
+
+struct BrowserURLPolicyFailure: Error {
+    let message: String
+}
+
+func validateBrowserNavigationURL(
+    _ rawURL: String,
+    allowAboutBlank: Bool = true,
+    resolveHostnames: Bool = true
+) -> Result<URLPolicyDecision, BrowserURLPolicyFailure> {
+    do {
+        let decision = try URLPolicy().validate(
+            rawURL,
+            options: URLPolicyOptions(allowAboutBlank: allowAboutBlank, resolveHostnames: resolveHostnames)
+        )
+        return .success(decision)
+    } catch let error as WebSafetyError {
+        return .failure(BrowserURLPolicyFailure(message: error.message))
+    } catch {
+        return .failure(BrowserURLPolicyFailure(message: "Navigation URL could not be validated."))
+    }
+}
+
+func validateBrowserNavigationURL(
+    _ url: URL,
+    allowAboutBlank: Bool = true,
+    resolveHostnames: Bool = true
+) -> Result<URLPolicyDecision, BrowserURLPolicyFailure> {
+    do {
+        let decision = try URLPolicy().validate(
+            url,
+            options: URLPolicyOptions(allowAboutBlank: allowAboutBlank, resolveHostnames: resolveHostnames)
+        )
+        return .success(decision)
+    } catch let error as WebSafetyError {
+        return .failure(BrowserURLPolicyFailure(message: error.message))
+    } catch {
+        return .failure(BrowserURLPolicyFailure(message: "Navigation URL could not be validated."))
+    }
+}
+
+func safeBrowserURLString(_ url: String) -> String {
+    WebSafetyRedactor.redactURL(url).value
+}
+
+func safeBrowserText(_ text: String) -> String {
+    WebSafetyRedactor.redactText(text).value
+}
 
 // MARK: - Detail Level
 
@@ -26,6 +75,7 @@ class HeadlessBrowser: NSObject, WKNavigationDelegate, WKUIDelegate {
     private var webView: WKWebView!
     private var navigationSemaphore = DispatchSemaphore(value: 0)
     private var navigationError: Error?
+    private var navigationPolicyBlocked = false
     private var isLoaded = false
 
     // Element ref counter - increments with each snapshot
@@ -215,16 +265,21 @@ class HeadlessBrowser: NSObject, WKNavigationDelegate, WKUIDelegate {
     func navigate(
         to urlString: String, timeout: TimeInterval = 30, waitUntil: WaitUntil = .load
     ) -> (success: Bool, error: String?) {
-        guard let url = URL(string: urlString) else {
-            return (false, "Invalid URL: \(urlString)")
+        let decision: URLPolicyDecision
+        switch validateBrowserNavigationURL(urlString) {
+        case .success(let allowed):
+            decision = allowed
+        case .failure(let failure):
+            return (false, failure.message)
         }
 
         navigationError = nil
+        navigationPolicyBlocked = false
         isLoaded = false
         navigationSemaphore = DispatchSemaphore(value: 0)
 
         DispatchQueue.main.async {
-            let request = URLRequest(url: url, timeoutInterval: timeout)
+            let request = URLRequest(url: decision.url, timeoutInterval: timeout)
             self.webView.load(request)
         }
 
@@ -1344,12 +1399,46 @@ class HeadlessBrowser: NSObject, WKNavigationDelegate, WKUIDelegate {
         navigationSemaphore.signal()
     }
 
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let targetURL = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
+        switch validateBrowserNavigationURL(targetURL, resolveHostnames: true) {
+        case .success:
+            decisionHandler(.allow)
+        case .failure(let failure):
+            if isMainFrame {
+                navigationPolicyBlocked = true
+                navigationError = NSError(
+                    domain: "OsaurusBrowserURLPolicy",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: failure.message]
+                )
+                navigationSemaphore.signal()
+            }
+            decisionHandler(.cancel)
+        }
+    }
+
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        if navigationPolicyBlocked && navigationError != nil {
+            return
+        }
         navigationError = error
         navigationSemaphore.signal()
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        if navigationPolicyBlocked && navigationError != nil {
+            return
+        }
         navigationError = error
         navigationSemaphore.signal()
     }
@@ -1415,6 +1504,13 @@ class HeadlessBrowser: NSObject, WKNavigationDelegate, WKUIDelegate {
         }
         if clear {
             _ = evaluateJavaScript("window.__osaurus_network = [];")
+        }
+        requests = requests.map { entry in
+            var safe = entry
+            if let url = safe["url"] as? String {
+                safe["url"] = safeBrowserURLString(url)
+            }
+            return safe
         }
         return requests
     }
@@ -1728,10 +1824,10 @@ func toJSONString(_ value: Any?) -> String {
 // MARK: - Snapshot Formatting
 
 func formatSnapshotOutput(_ data: [String: Any], detail: DetailLevel) -> String {
-    let title = data["title"] as? String ?? ""
-    let url = data["url"] as? String ?? ""
+    let title = safeBrowserText(data["title"] as? String ?? "")
+    let url = safeBrowserURLString(data["url"] as? String ?? "")
     let hasMore = data["hasMore"] as? Bool ?? false
-    let bodyText = data["bodyText"] as? String ?? ""
+    let bodyText = safeBrowserText(data["bodyText"] as? String ?? "")
 
     switch detail {
     case .none:
@@ -1748,7 +1844,7 @@ func formatSnapshotOutput(_ data: [String: Any], detail: DetailLevel) -> String 
         for element in elements {
             let ref = element["ref"] as? String ?? ""
             let type = element["type"] as? String ?? ""
-            let text = element["text"] as? String ?? ""
+            let text = safeBrowserText(element["text"] as? String ?? "")
             let truncText = text.count > 20 ? String(text.prefix(20)) + "..." : text
 
             if !truncText.isEmpty {
@@ -1776,7 +1872,7 @@ func formatSnapshotOutput(_ data: [String: Any], detail: DetailLevel) -> String 
         for element in elements {
             let ref = element["ref"] as? String ?? ""
             let type = element["type"] as? String ?? ""
-            let text = element["text"] as? String ?? ""
+            let text = safeBrowserText(element["text"] as? String ?? "")
 
             var line = "[\(ref)] \(type)"
 
@@ -1786,16 +1882,16 @@ func formatSnapshotOutput(_ data: [String: Any], detail: DetailLevel) -> String 
 
             var attrs: [String] = []
             if let name = element["name"] as? String, !name.isEmpty {
-                attrs.append("name=\"\(name)\"")
+                attrs.append("name=\"\(safeBrowserText(name))\"")
             }
             if let placeholder = element["placeholder"] as? String, !placeholder.isEmpty {
-                attrs.append("placeholder=\"\(placeholder)\"")
+                attrs.append("placeholder=\"\(safeBrowserText(placeholder))\"")
             }
             if let href = element["href"] as? String, !href.isEmpty, type == "link" {
-                attrs.append("href=\"\(href)\"")
+                attrs.append("href=\"\(safeBrowserURLString(href))\"")
             }
             if let value = element["value"] as? String, !value.isEmpty {
-                attrs.append("value=\"\(value)\"")
+                attrs.append("value=\"\(safeBrowserText(value))\"")
             }
             if element["checked"] as? Bool == true {
                 attrs.append("checked")
@@ -1843,7 +1939,7 @@ func formatSnapshotOutput(_ data: [String: Any], detail: DetailLevel) -> String 
         for element in elements {
             let ref = element["ref"] as? String ?? ""
             let type = element["type"] as? String ?? ""
-            let text = element["text"] as? String ?? ""
+            let text = safeBrowserText(element["text"] as? String ?? "")
 
             var line = "[\(ref)] \(type)"
 
@@ -1853,22 +1949,22 @@ func formatSnapshotOutput(_ data: [String: Any], detail: DetailLevel) -> String 
 
             var attrs: [String] = []
             if let name = element["name"] as? String, !name.isEmpty {
-                attrs.append("name=\"\(name)\"")
+                attrs.append("name=\"\(safeBrowserText(name))\"")
             }
             if let id = element["id"] as? String, !id.isEmpty {
-                attrs.append("id=\"\(id)\"")
+                attrs.append("id=\"\(safeBrowserText(id))\"")
             }
             if let placeholder = element["placeholder"] as? String, !placeholder.isEmpty {
-                attrs.append("placeholder=\"\(placeholder)\"")
+                attrs.append("placeholder=\"\(safeBrowserText(placeholder))\"")
             }
             if let href = element["href"] as? String, !href.isEmpty {
-                attrs.append("href=\"\(href)\"")
+                attrs.append("href=\"\(safeBrowserURLString(href))\"")
             }
             if let value = element["value"] as? String, !value.isEmpty {
-                attrs.append("value=\"\(value)\"")
+                attrs.append("value=\"\(safeBrowserText(value))\"")
             }
             if let ariaLabel = element["ariaLabel"] as? String, !ariaLabel.isEmpty {
-                attrs.append("aria-label=\"\(ariaLabel)\"")
+                attrs.append("aria-label=\"\(safeBrowserText(ariaLabel))\"")
             }
             if element["checked"] as? Bool == true {
                 attrs.append("checked")
@@ -1988,7 +2084,10 @@ class PluginContext {
         }
 
         let detail = parseDetail(input.detail)
-        return autoSnapshot(detail: detail, actionPrefix: "Action: navigate to \(input.url) succeeded")
+        return autoSnapshot(
+            detail: detail,
+            actionPrefix: "Action: navigate to \(safeBrowserURLString(input.url)) succeeded"
+        )
     }
 
     /// Heuristic check for "this navigation landed on a login page". Looks at
@@ -2014,7 +2113,7 @@ class PluginContext {
             "code": "LOGIN_REQUIRED",
             "message": "Navigation landed on a login page (\(host))",
             "domain": host,
-            "url": finalURL,
+            "url": safeBrowserURLString(finalURL),
             "hint":
                 "Call browser_open_login with this URL so the user can sign in, then retry the original navigation. Do not ask the user for credentials in chat — the helper window handles authentication, including 2FA.",
         ]
@@ -2085,7 +2184,7 @@ class PluginContext {
             "timed_out": result.timedOut,
             "profile_id": profileId.uuidString,
         ]
-        if let url = result.finalURL { data["final_url"] = url }
+        if let url = result.finalURL { data["final_url"] = safeBrowserURLString(url) }
         return envelopeOK(data)
     }
 

--- a/tools/browser/Tests/OsaurusBrowserTests/BrowserURLPolicyTests.swift
+++ b/tools/browser/Tests/OsaurusBrowserTests/BrowserURLPolicyTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import OsaurusToolSecurity
+
+@testable import OsaurusBrowser
+
+final class BrowserURLPolicyTests: XCTestCase {
+    func test_validateBrowserNavigationURL_allowsPublicHTTPS() throws {
+        let decision = try allowed("https://example.com/")
+        XCTAssertEqual(decision.url.scheme, "https")
+    }
+
+    func test_validateBrowserNavigationURL_allowsAboutBlankExplicitly() throws {
+        let decision = try allowed("about:blank")
+        XCTAssertTrue(decision.isAboutBlank)
+    }
+
+    func test_validateBrowserNavigationURL_blocksFileScheme() {
+        assertBlocked("file:///etc/passwd", contains: "Only http and https")
+    }
+
+    func test_validateBrowserNavigationURL_blocksMetadataEvenWhenEncoded() {
+        assertBlocked("http://2852039166/latest/meta-data/", contains: "metadata")
+    }
+
+    func test_validateBrowserNavigationURL_blocksUserInfo() {
+        assertBlocked("https://user:pass@example.com/", contains: "userinfo")
+    }
+
+    private func allowed(_ raw: String) throws -> URLPolicyDecision {
+        switch validateBrowserNavigationURL(raw) {
+        case .success(let decision):
+            return decision
+        case .failure(let failure):
+            throw NSError(domain: "BrowserURLPolicyTests", code: 1, userInfo: [NSLocalizedDescriptionKey: failure.message])
+        }
+    }
+
+    private func assertBlocked(_ raw: String, contains expected: String, file: StaticString = #file, line: UInt = #line) {
+        switch validateBrowserNavigationURL(raw) {
+        case .success:
+            XCTFail("expected URL to be blocked: \(raw)", file: file, line: line)
+        case .failure(let failure):
+            XCTAssertTrue(
+                failure.message.lowercased().contains(expected.lowercased()),
+                "message did not contain \(expected): \(failure.message)",
+                file: file,
+                line: line
+            )
+        }
+    }
+}

--- a/tools/browser/Tests/OsaurusBrowserTests/FormatSnapshotTests.swift
+++ b/tools/browser/Tests/OsaurusBrowserTests/FormatSnapshotTests.swift
@@ -119,6 +119,29 @@ final class FormatSnapshotTests: XCTestCase {
         XCTAssertTrue(result.contains("href=\"https://example.com/forgot\""))
     }
 
+    func testFormatStandard_redactsCredentialURLsAndText() {
+        let elements: [[String: Any]] = [
+            [
+                "ref": "E1", "type": "link", "text": "token=secret-value",
+                "href": "https://example.com/callback?access_token=secret-value",
+            ],
+            [
+                "ref": "E2", "type": "input", "value": "api_key=secret-value",
+            ],
+        ]
+        let data = makeSampleData(
+            title: "access_token=secret-value",
+            url: "https://example.com/page?token=secret-value",
+            elements: elements
+        )
+        let result = formatSnapshotOutput(data, detail: .standard)
+
+        XCTAssertFalse(result.contains("secret-value"))
+        XCTAssertTrue(result.contains("access_token=REDACTED"))
+        XCTAssertTrue(result.contains("token=REDACTED"))
+        XCTAssertTrue(result.contains("api_key=REDACTED"))
+    }
+
     func testFormatStandard_separatePageHeader() {
         let data = makeSampleData(title: "Test", url: "https://test.com")
         let result = formatSnapshotOutput(data, detail: .standard)

--- a/tools/fetch/Package.swift
+++ b/tools/fetch/Package.swift
@@ -7,9 +7,13 @@ let package = Package(
     products: [
         .library(name: "OsaurusFetch", type: .dynamic, targets: ["OsaurusFetch"])
     ],
+    dependencies: [
+        .package(path: "../../Shared/OsaurusToolSecurity")
+    ],
     targets: [
         .target(
             name: "OsaurusFetch",
+            dependencies: ["OsaurusToolSecurity"],
             path: "Sources/OsaurusFetch"
         ),
         .testTarget(

--- a/tools/fetch/Sources/OsaurusFetch/Plugin.swift
+++ b/tools/fetch/Sources/OsaurusFetch/Plugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OsaurusToolSecurity
 
 #if canImport(Darwin)
     import Darwin
@@ -228,18 +229,22 @@ struct MultipartField: Decodable {
 
 final class FetchDelegate: NSObject, URLSessionDataDelegate, URLSessionTaskDelegate {
     var redirectChain: [String] = []
+    var warnings: [String] = []
     var collected = Data()
     var truncated = false
     let maxBytes: Int
     let followRedirects: Bool
+    let allowPrivate: Bool
+    let redirectPolicy = RedirectPolicy()
     var protocolName: String?
     private let semaphore = DispatchSemaphore(value: 0)
     var taskError: Error?
     var response: HTTPURLResponse?
 
-    init(maxBytes: Int, followRedirects: Bool = true) {
+    init(maxBytes: Int, followRedirects: Bool = true, allowPrivate: Bool = false) {
         self.maxBytes = maxBytes
         self.followRedirects = followRedirects
+        self.allowPrivate = allowPrivate
     }
 
     func wait(timeout: TimeInterval) {
@@ -254,12 +259,50 @@ final class FetchDelegate: NSObject, URLSessionDataDelegate, URLSessionTaskDeleg
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
         if let oldURL = response.url?.absoluteString {
-            redirectChain.append(oldURL)
+            redirectChain.append(safeURLString(oldURL))
         }
         // Honor `follow_redirects: false`. Returning nil to the completion
         // handler stops the redirect; the original 3xx response is delivered
         // and `taskError` stays nil.
-        completionHandler(followRedirects ? request : nil)
+        guard followRedirects else {
+            completionHandler(nil)
+            return
+        }
+
+        guard let currentURL = response.url, let targetURL = request.url else {
+            taskError = ToolError(code: "INVALID_REDIRECT", message: "Redirect target was missing or invalid.")
+            completionHandler(nil)
+            return
+        }
+
+        do {
+            let decision = try redirectPolicy.evaluate(
+                from: currentURL,
+                to: targetURL,
+                headers: request.allHTTPHeaderFields ?? [:],
+                options: URLPolicyOptions(allowPrivateNetwork: allowPrivate)
+            )
+
+            var sanitized = request
+            let originalHeaders = request.allHTTPHeaderFields ?? [:]
+            for name in originalHeaders.keys {
+                sanitized.setValue(nil, forHTTPHeaderField: name)
+            }
+            for (name, value) in decision.headers {
+                sanitized.setValue(value, forHTTPHeaderField: name)
+            }
+            if decision.strippedSensitiveHeaders {
+                warnings.append("sensitive redirect headers were stripped for \(decision.target.redactedURL)")
+            }
+            warnings.append(contentsOf: decision.target.warnings)
+            completionHandler(sanitized)
+        } catch let error as WebSafetyError {
+            taskError = toolError(from: error, allowPrivate: allowPrivate)
+            completionHandler(nil)
+        } catch {
+            taskError = error
+            completionHandler(nil)
+        }
     }
 
     func urlSession(
@@ -321,6 +364,7 @@ struct HTTPResult {
     let redirectChain: [String]
     let protocolVersion: String?
     let truncated: Bool
+    let warnings: [String]
 }
 
 func executeRequest(
@@ -330,7 +374,8 @@ func executeRequest(
     body: RequestBody,
     timeout: TimeInterval,
     maxBytes: Int,
-    followRedirects: Bool
+    followRedirects: Bool,
+    allowPrivate: Bool
 ) throws -> HTTPResult {
     var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
     request.httpMethod = method.uppercased()
@@ -404,7 +449,7 @@ func executeRequest(
         request.setValue(v, forHTTPHeaderField: k)
     }
 
-    let delegate = FetchDelegate(maxBytes: maxBytes, followRedirects: followRedirects)
+    let delegate = FetchDelegate(maxBytes: maxBytes, followRedirects: followRedirects, allowPrivate: allowPrivate)
     let config = URLSessionConfiguration.ephemeral
     config.httpMaximumConnectionsPerHost = 4
     let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
@@ -414,6 +459,12 @@ func executeRequest(
     session.invalidateAndCancel()
 
     if let err = delegate.taskError {
+        if let toolError = err as? ToolError {
+            throw toolError
+        }
+        if let safetyError = err as? WebSafetyError {
+            throw toolError(from: safetyError, allowPrivate: allowPrivate)
+        }
         let nserr = err as NSError
         let code: String
         switch nserr.code {
@@ -441,7 +492,8 @@ func executeRequest(
         finalURL: response.url?.absoluteString ?? url.absoluteString,
         redirectChain: delegate.redirectChain,
         protocolVersion: delegate.protocolName,
-        truncated: delegate.truncated
+        truncated: delegate.truncated,
+        warnings: delegate.warnings
     )
 }
 
@@ -484,20 +536,119 @@ func headersFromAuth(_ auth: AuthHelper?) throws -> [String: String] {
 
 func parseURL(_ s: String) throws -> URL {
     guard let url = URL(string: s) else {
-        throw ToolError(code: "INVALID_ARGS", message: "Invalid URL: '\(s)'")
+        throw ToolError(code: "INVALID_ARGS", message: "Invalid URL: '\(safeURLString(s))'")
     }
     return url
 }
 
 func enforceSSRF(_ url: URL, allowPrivate: Bool) throws {
-    let check = checkSSRF(url: url, allowPrivate: allowPrivate)
-    if !check.allowed {
-        throw ToolError(
-            code: "SSRF_BLOCKED",
-            message: check.reason ?? "Request blocked by SSRF guard",
-            hint: "Set 'allow_private': true to bypass (use only for trusted local URLs)."
+    _ = try enforceURLPolicy(url, allowPrivate: allowPrivate)
+}
+
+func enforceURLPolicy(_ url: URL, allowPrivate: Bool) throws -> URLPolicyDecision {
+    do {
+        return try URLPolicy().validate(
+            url,
+            options: URLPolicyOptions(allowPrivateNetwork: allowPrivate)
         )
+    } catch let error as WebSafetyError {
+        throw toolError(from: error, allowPrivate: allowPrivate)
     }
+}
+
+func toolError(from error: WebSafetyError, allowPrivate: Bool) -> ToolError {
+    let hint: String?
+    switch error.code {
+    case .ssrfBlocked:
+        hint = allowPrivate
+            ? "Cloud metadata endpoints stay blocked even when private network access is allowed."
+            : "Set 'allow_private': true only for trusted local/private network URLs. Metadata endpoints remain blocked."
+    case .secretInURL:
+        hint = "Move credentials into the 'auth' helper or request headers instead of embedding them in the URL."
+    case .unsafeScheme:
+        hint = "Use an http or https URL."
+    case .downloadPathInvalid:
+        hint = "Pass a plain filename without directories."
+    }
+    return ToolError(code: error.code.rawValue, message: error.message, hint: hint)
+}
+
+func safeURLString(_ url: String) -> String {
+    WebSafetyRedactor.redactURL(url).value
+}
+
+func safeURLList(_ urls: [String]) -> [String] {
+    urls.map(safeURLString)
+}
+
+func safeHeaders(_ headers: [String: String]) -> [String: String] {
+    WebSafetyRedactor.redactHeaders(headers).value
+}
+
+func safeText(_ text: String) -> (value: String, redacted: Bool) {
+    let result = WebSafetyRedactor.redactText(text)
+    return (result.value, result.redacted)
+}
+
+func safeBodyFields(_ body: Data) -> (body: String, bodyBase64: String, redacted: Bool) {
+    guard let text = String(data: body, encoding: .utf8) else {
+        return ("", body.base64EncodedString(), false)
+    }
+    let redacted = safeText(text)
+    let redactedData = redacted.value.data(using: .utf8) ?? Data()
+    return (redacted.value, redactedData.base64EncodedString(), redacted.redacted)
+}
+
+func safeJSONValue(_ value: Any, key: String? = nil) -> (value: Any, redacted: Bool) {
+    if let key, isSensitiveJSONKey(key) {
+        return ("REDACTED", true)
+    }
+
+    if let string = value as? String {
+        let redacted = safeText(string)
+        return (redacted.value, redacted.redacted)
+    }
+
+    if let dict = value as? [String: Any] {
+        var output: [String: Any] = [:]
+        var didRedact = false
+        for (childKey, childValue) in dict {
+            let safe = safeJSONValue(childValue, key: childKey)
+            output[childKey] = safe.value
+            didRedact = didRedact || safe.redacted
+        }
+        return (output, didRedact)
+    }
+
+    if let array = value as? [Any] {
+        var didRedact = false
+        let output = array.map { item -> Any in
+            let safe = safeJSONValue(item)
+            didRedact = didRedact || safe.redacted
+            return safe.value
+        }
+        return (output, didRedact)
+    }
+
+    return (value, false)
+}
+
+private func isSensitiveJSONKey(_ key: String) -> Bool {
+    let normalized = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased()
+        .replacingOccurrences(of: "_", with: "-")
+    if WebSafetyRedactor.isSensitiveHeaderName(normalized) {
+        return true
+    }
+    return normalized == "key"
+        || normalized.contains("token")
+        || normalized.contains("secret")
+        || normalized.contains("password")
+        || normalized == "passwd"
+        || normalized == "pwd"
+        || normalized.contains("credential")
+        || normalized.contains("signature")
+        || normalized == "sig"
 }
 
 /// Pick a safe download target under ~/Downloads.
@@ -509,35 +660,25 @@ func enforceSSRF(_ url: URL, allowPrivate: Bool) throws {
 /// Exposed (non-throwing of any non-ToolError) so tests can drive it without
 /// performing an HTTP request.
 func resolveDownloadTarget(requestedFilename: String?, url: URL) throws -> URL {
-    let candidate: String = {
-        if let user = requestedFilename, !user.isEmpty { return user }
-        if let last = url.pathComponents.last, !last.isEmpty, last != "/" { return last }
-        return "download_\(Int(Date().timeIntervalSince1970))"
-    }()
-
-    if candidate.contains("/") || candidate.contains("\\") || candidate.contains("..")
-        || candidate.hasPrefix(".") || candidate.hasPrefix("~")
-    {
-        throw ToolError(
-            code: "DOWNLOAD_PATH_INVALID",
-            message: "Filename contains path separators, '..', or starts with '.': '\(candidate)'",
-            hint: "Pass a plain filename without directories — it will always land in ~/Downloads."
-        )
-    }
-
     let downloadsDir = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Downloads")
         .standardizedFileURL
-    let target = downloadsDir.appendingPathComponent(candidate).standardizedFileURL
-
-    if !target.path.hasPrefix(downloadsDir.path + "/") {
-        throw ToolError(
-            code: "DOWNLOAD_PATH_INVALID",
-            message: "Resolved path '\(target.path)' is outside ~/Downloads",
-            hint: "Pass a plain filename only."
-        )
+    let sourceForFilename: URL?
+    let lastPathComponent = url.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+    if lastPathComponent.isEmpty || lastPathComponent == "/" {
+        sourceForFilename = nil
+    } else {
+        sourceForFilename = url
     }
-    return target
+    do {
+        return try DownloadPathValidator(baseDirectory: downloadsDir).resolve(
+            requestedFilename: requestedFilename,
+            sourceURL: sourceForFilename,
+            defaultFilename: "download_\(Int(Date().timeIntervalSince1970))"
+        )
+    } catch let error as WebSafetyError {
+        throw toolError(from: error, allowPrivate: false)
+    }
 }
 
 struct CommonRequestArgs: Decodable {
@@ -632,7 +773,8 @@ struct FetchTool {
     func run(args: String) throws -> [String: Any] {
         let parsed: CommonRequestArgs = try decodeArgs(args)
         let url = try parseURL(parsed.url)
-        try enforceSSRF(url, allowPrivate: parsed.allow_private ?? false)
+        let allowPrivate = parsed.allow_private ?? false
+        let policy = try enforceURLPolicy(url, allowPrivate: allowPrivate)
 
         var headers = parsed.headers ?? [:]
         for (k, v) in try headersFromAuth(parsed.auth) {
@@ -646,19 +788,23 @@ struct FetchTool {
             body: try bodyFromArgs(parsed),
             timeout: parsed.timeout ?? 30,
             maxBytes: parsed.max_bytes ?? 10 * 1024 * 1024,
-            followRedirects: parsed.follow_redirects ?? true
+            followRedirects: parsed.follow_redirects ?? true,
+            allowPrivate: allowPrivate
         )
 
+        let body = safeBodyFields(result.body)
         return [
             "status": result.status,
-            "final_url": result.finalURL,
-            "redirect_chain": result.redirectChain,
+            "final_url": safeURLString(result.finalURL),
+            "redirect_chain": safeURLList(result.redirectChain),
             "protocol_version": result.protocolVersion ?? NSNull(),
-            "headers": result.headers,
-            "body": String(data: result.body, encoding: .utf8) ?? "",
-            "body_base64": result.body.base64EncodedString(),
+            "headers": safeHeaders(result.headers),
+            "body": body.body,
+            "body_base64": body.bodyBase64,
             "byte_count": result.body.count,
+            "body_redacted": body.redacted,
             "truncated": result.truncated,
+            "policy_warnings": policy.warnings + result.warnings,
         ]
     }
 }
@@ -669,7 +815,8 @@ struct FetchJSONTool {
     func run(args: String) throws -> [String: Any] {
         let parsed: CommonRequestArgs = try decodeArgs(args)
         let url = try parseURL(parsed.url)
-        try enforceSSRF(url, allowPrivate: parsed.allow_private ?? false)
+        let allowPrivate = parsed.allow_private ?? false
+        let policy = try enforceURLPolicy(url, allowPrivate: allowPrivate)
 
         var headers = parsed.headers ?? [:]
         if headers["Accept"] == nil { headers["Accept"] = "application/json" }
@@ -684,22 +831,28 @@ struct FetchJSONTool {
             body: try bodyFromArgs(parsed),
             timeout: parsed.timeout ?? 30,
             maxBytes: parsed.max_bytes ?? 10 * 1024 * 1024,
-            followRedirects: parsed.follow_redirects ?? true
+            followRedirects: parsed.follow_redirects ?? true,
+            allowPrivate: allowPrivate
         )
 
         var data: [String: Any] = [
             "status": result.status,
-            "final_url": result.finalURL,
-            "redirect_chain": result.redirectChain,
+            "final_url": safeURLString(result.finalURL),
+            "redirect_chain": safeURLList(result.redirectChain),
             "protocol_version": result.protocolVersion ?? NSNull(),
-            "headers": result.headers,
+            "headers": safeHeaders(result.headers),
             "truncated": result.truncated,
+            "policy_warnings": policy.warnings + result.warnings,
         ]
         if let parsed = try? JSONSerialization.jsonObject(with: result.body) {
-            data["json"] = parsed
+            let safeJSON = safeJSONValue(parsed)
+            data["json"] = safeJSON.value
+            data["body_redacted"] = safeJSON.redacted
         } else {
             data["json"] = NSNull()
-            data["body"] = String(data: result.body, encoding: .utf8) ?? ""
+            let body = safeBodyFields(result.body)
+            data["body"] = body.body
+            data["body_redacted"] = body.redacted
             return data  // fall through with warning via caller? simpler: include both
         }
         return data
@@ -723,7 +876,8 @@ struct FetchHTMLTool {
         }
         let parsed: ExtractArgs = try decodeArgs(args)
         let url = try parseURL(parsed.url)
-        try enforceSSRF(url, allowPrivate: parsed.allow_private ?? false)
+        let allowPrivate = parsed.allow_private ?? false
+        let policy = try enforceURLPolicy(url, allowPrivate: allowPrivate)
 
         var headers: [String: String] = [
             "Accept": "text/html,application/xhtml+xml",
@@ -741,7 +895,8 @@ struct FetchHTMLTool {
             body: .none,
             timeout: parsed.timeout ?? 30,
             maxBytes: parsed.max_bytes ?? 10 * 1024 * 1024,
-            followRedirects: parsed.follow_redirects ?? true
+            followRedirects: parsed.follow_redirects ?? true,
+            allowPrivate: allowPrivate
         )
 
         guard let html = String(data: result.body, encoding: .utf8) else {
@@ -754,26 +909,33 @@ struct FetchHTMLTool {
         let mode = (parsed.extract ?? "readability").lowercased()
         var data: [String: Any] = [
             "status": result.status,
-            "final_url": result.finalURL,
-            "redirect_chain": result.redirectChain,
+            "final_url": safeURLString(result.finalURL),
+            "redirect_chain": safeURLList(result.redirectChain),
             "protocol_version": result.protocolVersion ?? NSNull(),
-            "headers": result.headers,
+            "headers": safeHeaders(result.headers),
             "truncated": result.truncated,
             "byte_count": result.body.count,
+            "policy_warnings": policy.warnings + result.warnings,
         ]
 
         switch mode {
         case "raw":
-            data["html"] = html
+            let redacted = safeText(html)
+            data["html"] = redacted.value
+            data["body_redacted"] = redacted.redacted
         case "text":
-            data["text"] = htmlToPlainText(html)
+            let redacted = safeText(htmlToPlainText(html))
+            data["text"] = redacted.value
+            data["body_redacted"] = redacted.redacted
         default:  // readability
             let extracted = readabilityExtract(html: html, selector: parsed.selector)
             data["title"] = extracted.title ?? NSNull()
             data["byline"] = extracted.byline ?? NSNull()
             data["excerpt"] = extracted.excerpt ?? NSNull()
             data["lang"] = extracted.lang ?? NSNull()
-            data["markdown"] = extracted.markdown
+            let redacted = safeText(extracted.markdown)
+            data["markdown"] = redacted.value
+            data["body_redacted"] = redacted.redacted
             data["word_count"] = extracted.wordCount
         }
         return data
@@ -794,7 +956,8 @@ struct DownloadTool {
         }
         let parsed: DownloadArgs = try decodeArgs(args)
         let url = try parseURL(parsed.url)
-        try enforceSSRF(url, allowPrivate: parsed.allow_private ?? false)
+        let allowPrivate = parsed.allow_private ?? false
+        let policy = try enforceURLPolicy(url, allowPrivate: allowPrivate)
 
         var headers: [String: String] = [:]
         for (k, v) in try headersFromAuth(parsed.auth) {
@@ -808,7 +971,8 @@ struct DownloadTool {
             body: .none,
             timeout: parsed.timeout ?? 60,
             maxBytes: parsed.max_bytes ?? 100 * 1024 * 1024,
-            followRedirects: true
+            followRedirects: true,
+            allowPrivate: allowPrivate
         )
 
         let target = try resolveDownloadTarget(
@@ -829,8 +993,9 @@ struct DownloadTool {
             "path": target.path,
             "size": result.body.count,
             "status": result.status,
-            "final_url": result.finalURL,
+            "final_url": safeURLString(result.finalURL),
             "truncated": result.truncated,
+            "policy_warnings": policy.warnings + result.warnings,
         ]
     }
 }

--- a/tools/fetch/Tests/OsaurusFetchTests/SSRFTests.swift
+++ b/tools/fetch/Tests/OsaurusFetchTests/SSRFTests.swift
@@ -113,4 +113,96 @@ final class SSRFTests: XCTestCase {
         let result = checkSSRF(url: url, allowPrivate: true)
         XCTAssertTrue(result.allowed)
     }
+
+    // MARK: shared policy adoption
+
+    func test_enforceSSRF_blocksUnsafeSchemeEvenWhenPrivateAllowed() {
+        let url = URL(string: "file:///etc/passwd")!
+        XCTAssertThrowsError(try enforceSSRF(url, allowPrivate: true)) { error in
+            guard let toolError = error as? ToolError else {
+                return XCTFail("expected ToolError, got \(error)")
+            }
+            XCTAssertEqual(toolError.code, "UNSAFE_SCHEME")
+        }
+    }
+
+    func test_enforceSSRF_blocksMetadataEvenWhenPrivateAllowed() {
+        let url = URL(string: "http://169.254.169.254/latest/meta-data/")!
+        XCTAssertThrowsError(try enforceSSRF(url, allowPrivate: true)) { error in
+            guard let toolError = error as? ToolError else {
+                return XCTFail("expected ToolError, got \(error)")
+            }
+            XCTAssertEqual(toolError.code, "SSRF_BLOCKED")
+            XCTAssertTrue(toolError.message.contains("metadata"))
+        }
+    }
+
+    func test_enforceSSRF_rejectsURLUserInfo() {
+        let url = URL(string: "https://user:pass@example.com/")!
+        XCTAssertThrowsError(try enforceSSRF(url, allowPrivate: false)) { error in
+            guard let toolError = error as? ToolError else {
+                return XCTFail("expected ToolError, got \(error)")
+            }
+            XCTAssertEqual(toolError.code, "SECRET_IN_URL")
+        }
+    }
+
+    func test_safeHeaders_redactsSensitiveValues() {
+        let redacted = safeHeaders([
+            "Authorization": "Bearer secret-token",
+            "X-Request-ID": "abc",
+            "Cookie": "session=abc",
+        ])
+        XCTAssertEqual(redacted["Authorization"], "<redacted>")
+        XCTAssertEqual(redacted["Cookie"], "<redacted>")
+        XCTAssertEqual(redacted["X-Request-ID"], "abc")
+    }
+
+    func test_safeURLString_redactsQueryAndFragmentSecrets() {
+        let redacted = safeURLString("https://example.com/path?token=abc#access_token=xyz")
+        XCTAssertFalse(redacted.contains("abc"))
+        XCTAssertFalse(redacted.contains("xyz"))
+        XCTAssertTrue(redacted.contains("token=REDACTED"))
+    }
+
+    func test_parseURL_redactsInvalidInputInErrorMessage() {
+        XCTAssertThrowsError(try parseURL("https://example .com/path?token=secret-value")) { error in
+            guard let toolError = error as? ToolError else {
+                return XCTFail("expected ToolError, got \(error)")
+            }
+            XCTAssertEqual(toolError.code, "INVALID_ARGS")
+            XCTAssertFalse(toolError.message.contains("secret-value"))
+            XCTAssertTrue(toolError.message.contains("token=REDACTED"))
+        }
+    }
+
+    func test_safeBodyFields_redactsTextAndBase64Mirror() throws {
+        let fields = safeBodyFields(Data("Authorization: Bearer secret12345".utf8))
+        XCTAssertTrue(fields.redacted)
+        XCTAssertFalse(fields.body.contains("secret12345"))
+        let decoded = try XCTUnwrap(String(data: try XCTUnwrap(Data(base64Encoded: fields.bodyBase64)), encoding: .utf8))
+        XCTAssertEqual(decoded, fields.body)
+    }
+
+    func test_safeJSONValue_redactsSensitiveKeysAndStringLeaves() throws {
+        let input: [String: Any] = [
+            "access_token": "secret-value",
+            "profile": [
+                "name": "Ada",
+                "callback": "https://example.com/callback?token=secret-value",
+            ],
+            "items": [
+                ["api_key": "secret-value"],
+                "Authorization: Bearer secret12345",
+            ],
+        ]
+
+        let safe = safeJSONValue(input)
+        XCTAssertTrue(safe.redacted)
+        let output = try XCTUnwrap(safe.value as? [String: Any])
+        XCTAssertEqual(output["access_token"] as? String, "REDACTED")
+        XCTAssertFalse(String(describing: output).contains("secret-value"))
+        XCTAssertFalse(String(describing: output).contains("secret12345"))
+        XCTAssertTrue(String(describing: output).contains("token=REDACTED"))
+    }
 }

--- a/tools/search/Package.swift
+++ b/tools/search/Package.swift
@@ -7,9 +7,13 @@ let package = Package(
     products: [
         .library(name: "OsaurusSearch", type: .dynamic, targets: ["OsaurusSearch"])
     ],
+    dependencies: [
+        .package(path: "../../Shared/OsaurusToolSecurity")
+    ],
     targets: [
         .target(
             name: "OsaurusSearch",
+            dependencies: ["OsaurusToolSecurity"],
             path: "Sources/OsaurusSearch"
         ),
         .testTarget(

--- a/tools/search/Sources/OsaurusSearch/Plugin.swift
+++ b/tools/search/Sources/OsaurusSearch/Plugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OsaurusToolSecurity
 
 // MARK: - Response Envelope
 
@@ -81,6 +82,29 @@ struct BackendError: Error, Equatable {
     init(_ message: String) { self.message = message }
 }
 
+struct ExtractionAttempt {
+    let data: [String: Any]?
+    let errorCode: String?
+    let message: String?
+    let warnings: [String]
+
+    static func success(_ data: [String: Any], warnings: [String] = []) -> ExtractionAttempt {
+        ExtractionAttempt(data: data, errorCode: nil, message: nil, warnings: warnings)
+    }
+
+    static func failure(code: String, message: String, warnings: [String] = []) -> ExtractionAttempt {
+        ExtractionAttempt(data: nil, errorCode: code, message: message, warnings: warnings)
+    }
+}
+
+private func redactedURLForOutput(_ url: String) -> String {
+    WebSafetyRedactor.redactURL(url).value
+}
+
+private func redactedTextForOutput(_ text: String) -> String {
+    WebSafetyRedactor.redactText(text).value
+}
+
 // MARK: - HTTP
 
 let userAgents = [
@@ -125,6 +149,159 @@ private func httpRequest(
         return (0, nil, error ?? "request timed out after \(Int(timeout))s")
     }
     return (status, data, error)
+}
+
+private final class ExtractionRequestDelegate: NSObject, URLSessionDataDelegate, URLSessionTaskDelegate {
+    private let redirectPolicy = RedirectPolicy()
+    private let maxBytes: Int
+    private let semaphore = DispatchSemaphore(value: 0)
+    private(set) var data = Data()
+    private(set) var status = 0
+    private(set) var warnings: [String] = []
+    private(set) var finalURL: String?
+    private(set) var error: Error?
+    private(set) var truncated = false
+
+    init(maxBytes: Int) {
+        self.maxBytes = maxBytes
+    }
+
+    func wait(timeout: TimeInterval) {
+        _ = semaphore.wait(timeout: .now() + timeout)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let currentURL = response.url, let targetURL = request.url else {
+            error = ToolError(code: "INVALID_REDIRECT", message: "Redirect target was missing or invalid.")
+            completionHandler(nil)
+            return
+        }
+        do {
+            let decision = try redirectPolicy.evaluate(
+                from: currentURL,
+                to: targetURL,
+                headers: request.allHTTPHeaderFields ?? [:],
+                options: URLPolicyOptions()
+            )
+            var sanitized = request
+            let originalHeaders = request.allHTTPHeaderFields ?? [:]
+            for name in originalHeaders.keys {
+                sanitized.setValue(nil, forHTTPHeaderField: name)
+            }
+            for (name, value) in decision.headers {
+                sanitized.setValue(value, forHTTPHeaderField: name)
+            }
+            if decision.strippedSensitiveHeaders {
+                warnings.append("sensitive redirect headers were stripped for \(decision.target.redactedURL)")
+            }
+            warnings.append(contentsOf: decision.target.warnings)
+            completionHandler(sanitized)
+        } catch {
+            self.error = error
+            completionHandler(nil)
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        if let http = response as? HTTPURLResponse {
+            status = http.statusCode
+            finalURL = http.url?.absoluteString
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive chunk: Data) {
+        if data.count >= maxBytes {
+            truncated = true
+            dataTask.cancel()
+            return
+        }
+        let remaining = maxBytes - data.count
+        if chunk.count > remaining {
+            data.append(chunk.prefix(remaining))
+            truncated = true
+            dataTask.cancel()
+        } else {
+            data.append(chunk)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error as NSError?,
+            !(error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled && truncated)
+        {
+            self.error = error
+        }
+        semaphore.signal()
+    }
+}
+
+private func safeExtractionGET(url: String, timeout: TimeInterval, maxBytes: Int = 2 * 1024 * 1024)
+    -> ExtractionAttempt
+{
+    do {
+        let policy = try URLPolicy().validate(url, options: URLPolicyOptions())
+        var request = URLRequest(url: policy.url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: timeout)
+        request.setValue(userAgents.randomElement() ?? userAgents[0], forHTTPHeaderField: "User-Agent")
+        request.setValue("text/html,application/xhtml+xml", forHTTPHeaderField: "Accept")
+        request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+
+        let delegate = ExtractionRequestDelegate(maxBytes: maxBytes)
+        let config = URLSessionConfiguration.ephemeral
+        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
+        let task = session.dataTask(with: request)
+        task.resume()
+        delegate.wait(timeout: timeout + 2)
+        session.invalidateAndCancel()
+
+        if let error = delegate.error {
+            let code: String
+            let message: String
+            if let safety = error as? WebSafetyError {
+                code = safety.code.rawValue
+                message = safety.message
+            } else if let tool = error as? ToolError {
+                code = tool.code
+                message = tool.message
+            } else {
+                code = "EXTRACTION_REQUEST_FAILED"
+                message = error.localizedDescription
+            }
+            return .failure(code: code, message: message, warnings: policy.warnings + delegate.warnings)
+        }
+
+        guard !delegate.data.isEmpty else {
+            return .failure(
+                code: "EXTRACTION_EMPTY_RESPONSE",
+                message: "No extractable response body was returned.",
+                warnings: policy.warnings + delegate.warnings
+            )
+        }
+        return .success(
+            [
+                "data": delegate.data,
+                "status": delegate.status,
+                "final_url": redactedURLForOutput(delegate.finalURL ?? policy.redactedURL),
+                "truncated": delegate.truncated,
+            ],
+            warnings: policy.warnings + delegate.warnings
+        )
+    } catch let error as WebSafetyError {
+        return .failure(code: error.code.rawValue, message: error.message)
+    } catch {
+        return .failure(code: "EXTRACTION_REQUEST_FAILED", message: error.localizedDescription)
+    }
 }
 
 // MARK: - HTML helpers
@@ -1271,18 +1448,34 @@ private struct SearchAndExtractTool {
         for (i, hit) in results.enumerated() {
             var entry = hit
             if i < extractCount, let url = hit["url"] as? String {
-                if let extracted = extractReadability(url: url, timeout: timeout) {
+                let attempt = extractReadability(url: url, timeout: timeout)
+                if let extracted = attempt.data {
                     entry["title"] = extracted["title"] ?? entry["title"] ?? NSNull()
                     entry["markdown"] = extracted["markdown"] ?? ""
                     entry["word_count"] = extracted["word_count"] ?? 0
                     entry["byline"] = extracted["byline"] ?? NSNull()
                     entry["lang"] = extracted["lang"] ?? NSNull()
+                    entry["final_url"] = extracted["final_url"] ?? redactedURLForOutput(url)
+                    entry["truncated"] = extracted["truncated"] ?? false
                     entry["extracted"] = true
                 } else {
                     entry["extracted"] = false
+                    if let code = attempt.errorCode {
+                        entry["extraction_error_code"] = code
+                    }
+                    if let message = attempt.message {
+                        entry["extraction_error"] = message
+                    }
                 }
+                if !attempt.warnings.isEmpty {
+                    entry["extraction_warnings"] = attempt.warnings
+                }
+                entry["url"] = redactedURLForOutput(url)
             } else {
                 entry["extracted"] = false
+                if let url = hit["url"] as? String {
+                    entry["url"] = redactedURLForOutput(url)
+                }
             }
             enriched.append(entry)
         }
@@ -1294,16 +1487,17 @@ private struct SearchAndExtractTool {
 }
 
 // Lightweight Readability extraction used only by search_and_extract.
-private func extractReadability(url: String, timeout: TimeInterval) -> [String: Any]? {
-    let res = httpRequest(
-        url: url,
-        headers: [
-            "Accept": "text/html,application/xhtml+xml"
-        ],
-        timeout: timeout
-    )
-    guard let data = res.data, let html = String(data: data, encoding: .utf8) else {
-        return nil
+func extractReadability(url: String, timeout: TimeInterval) -> ExtractionAttempt {
+    let res = safeExtractionGET(url: url, timeout: timeout)
+    guard let raw = res.data else {
+        return res
+    }
+    guard let data = raw["data"] as? Data, let html = String(data: data, encoding: .utf8) else {
+        return .failure(
+            code: "EXTRACTION_DECODE_FAILED",
+            message: "Extracted response body is not UTF-8 text.",
+            warnings: res.warnings
+        )
     }
 
     let title = firstGroup(in: html, pattern: "<title[^>]*>([\\s\\S]*?)</title>")
@@ -1320,14 +1514,16 @@ private func extractReadability(url: String, timeout: TimeInterval) -> [String: 
             "button",
         ])
     if let main = pickMainContainer(content) { content = main }
-    let markdown = htmlToMarkdown(content)
+    let markdown = redactedTextForOutput(htmlToMarkdown(content))
     let wordCount = markdown.split(whereSeparator: { $0.isWhitespace }).count
 
     var d: [String: Any] = ["markdown": markdown, "word_count": wordCount]
-    if let t = title { d["title"] = t }
-    if let b = byline { d["byline"] = b }
-    if let l = lang { d["lang"] = l }
-    return d
+    d["final_url"] = raw["final_url"] ?? redactedURLForOutput(url)
+    d["truncated"] = raw["truncated"] ?? false
+    if let t = title { d["title"] = redactedTextForOutput(t) }
+    if let b = byline { d["byline"] = redactedTextForOutput(b) }
+    if let l = lang { d["lang"] = redactedTextForOutput(l) }
+    return .success(d, warnings: res.warnings)
 }
 
 func firstGroup(in s: String, pattern: String, group: Int = 1) -> String? {

--- a/tools/search/Tests/OsaurusSearchTests/ExtractionSafetyTests.swift
+++ b/tools/search/Tests/OsaurusSearchTests/ExtractionSafetyTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+@testable import OsaurusSearch
+
+final class ExtractionSafetyTests: XCTestCase {
+    func test_extractReadability_blocksUnsafeSchemeWithoutNetwork() {
+        let attempt = extractReadability(url: "file:///etc/passwd", timeout: 0.01)
+        XCTAssertNil(attempt.data)
+        XCTAssertEqual(attempt.errorCode, "UNSAFE_SCHEME")
+    }
+
+    func test_extractReadability_blocksMetadataAddressWithoutNetwork() {
+        let attempt = extractReadability(url: "http://169.254.169.254/latest/meta-data/", timeout: 0.01)
+        XCTAssertNil(attempt.data)
+        XCTAssertEqual(attempt.errorCode, "SSRF_BLOCKED")
+        XCTAssertTrue(attempt.message?.contains("metadata") ?? false)
+    }
+
+    func test_extractReadability_blocksURLUserInfo() {
+        let attempt = extractReadability(url: "https://user:pass@example.com/", timeout: 0.01)
+        XCTAssertNil(attempt.data)
+        XCTAssertEqual(attempt.errorCode, "SECRET_IN_URL")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the shared web safety core and wires it into fetch, search extraction, and browser navigation paths.
- Re-validates redirects, blocks unsafe schemes/userinfo/metadata/private hops, strips sensitive redirect headers, and keeps typed policy errors.
- Redacts agent-visible URLs, headers, response bodies, structured JSON leaves, browser snapshots, login URLs, and extraction metadata.
- Keeps browser login URL validation off the UI thread while using DNS-backed checks for user-entered URLs and headless navigation.

## Validation
- swift test --package-path Shared/OsaurusToolSecurity
- swift test --package-path tools/fetch
- swift test --package-path tools/search
- swift test --package-path tools/browser
- git diff --check
- python3 scripts/validate.py
- python3 scripts/regenerate-catalogs.py --check --tool browser --tool fetch --tool search
- for tool in browser fetch search; do (cd tools/$tool && swift build -c release) || exit 1; done

## Notes
- Ready for review. GitHub currently reports no status checks for this tools PR; merge remains blocked until maintainer review.
- Browser WebKit integration tests remain gated by the existing test environment; the plain SwiftPM browser suite passes with the existing WebKit-gated cases skipped.