### PR TITLE
Fix browser snapshot filters

### DIFF
--- a/tools/browser/Sources/OsaurusBrowser/Plugin.swift
+++ b/tools/browser/Sources/OsaurusBrowser/Plugin.swift
@@ -373,6 +373,21 @@ class HeadlessBrowser: NSObject, WKNavigationDelegate, WKUIDelegate {
         var visibleOnly: Bool = true
     }
 
+    static func snapshotFilterCondition(for filter: String, nodeVariable: String = "node") -> String {
+        switch filter {
+        case "inputs":
+            return "\(nodeVariable).matches('input, textarea, select, [contenteditable=\"true\"]')"
+        case "buttons":
+            return "\(nodeVariable).matches('button, input[type=\"button\"], input[type=\"submit\"], [role=\"button\"]')"
+        case "links":
+            return "\(nodeVariable).matches('a[href]')"
+        case "forms":
+            return "\(nodeVariable).matches('form, input, textarea, select, button')"
+        default:
+            return "true"
+        }
+    }
+
     func takeSnapshot(options: SnapshotOptions = SnapshotOptions(), detail: DetailLevel = .standard) -> String {
         // Validate state before attempting snapshot
         guard hasNavigated else {
@@ -384,19 +399,7 @@ class HeadlessBrowser: NSObject, WKNavigationDelegate, WKUIDelegate {
         snapshotGeneration += 1
         let currentGeneration = snapshotGeneration
 
-        let filterCondition: String
-        switch options.filter {
-        case "inputs":
-            filterCondition = "el.matches('input, textarea, select, [contenteditable=\"true\"]')"
-        case "buttons":
-            filterCondition = "el.matches('button, input[type=\"button\"], input[type=\"submit\"], [role=\"button\"]')"
-        case "links":
-            filterCondition = "el.matches('a[href]')"
-        case "forms":
-            filterCondition = "el.matches('form, input, textarea, select, button')"
-        default:
-            filterCondition = "true"
-        }
+        let filterCondition = Self.snapshotFilterCondition(for: options.filter)
 
         let visibilityCheck =
             options.visibleOnly

--- a/tools/browser/Tests/OsaurusBrowserTests/BrowserTestCase.swift
+++ b/tools/browser/Tests/OsaurusBrowserTests/BrowserTestCase.swift
@@ -26,7 +26,9 @@ class BrowserTestCase: XCTestCase {
             return
         }
 
-        if NSApp == nil {
+        if NSApp == nil, Thread.isMainThread {
+            _ = NSApplication.shared
+        } else if NSApp == nil {
             DispatchQueue.main.sync { _ = NSApplication.shared }
         }
 
@@ -64,6 +66,8 @@ class BrowserTestCase: XCTestCase {
         return result
     }
 
+    /// Returns a bundled test fixture URL. Keep this helper test-only so fixture
+    /// navigation stays separate from any production URL policy.
     func fixtureURL(_ name: String) -> String {
         let bundle = Bundle.module
         guard
@@ -84,10 +88,25 @@ class BrowserTestCase: XCTestCase {
         return browserSync { ctx.navigate(args: args) }
     }
 
-    func takeSnapshot(detail: String = "standard") -> String {
+    func takeSnapshot(
+        filter: String? = nil,
+        maxElements: Int? = nil,
+        visibleOnly: Bool? = nil,
+        detail: String = "standard"
+    ) -> String {
         guard let ctx = context else { return "" }
+        var fields = ["\"detail\": \"\(detail)\""]
+        if let filter {
+            fields.append("\"filter\": \"\(filter)\"")
+        }
+        if let maxElements {
+            fields.append("\"max_elements\": \(maxElements)")
+        }
+        if let visibleOnly {
+            fields.append("\"visible_only\": \(visibleOnly)")
+        }
+        let args = "{\(fields.joined(separator: ", "))}"
         return browserSync {
-            let args = "{\"detail\": \"\(detail)\"}"
             return ctx.snapshot(args: args)
         }
     }

--- a/tools/browser/Tests/OsaurusBrowserTests/SnapshotFilterTests.swift
+++ b/tools/browser/Tests/OsaurusBrowserTests/SnapshotFilterTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+@testable import OsaurusBrowser
+
+final class SnapshotFilterConditionTests: XCTestCase {
+
+    func testFilterConditionsReferenceTreeWalkerNode() {
+        for filter in ["inputs", "buttons", "links", "forms"] {
+            let condition = HeadlessBrowser.snapshotFilterCondition(for: filter)
+
+            XCTAssertTrue(
+                condition.contains("node.matches("),
+                "\(filter) filter should evaluate the TreeWalker node")
+            XCTAssertFalse(
+                condition.contains("el.matches("),
+                "\(filter) filter must not reference the walker loop variable")
+        }
+    }
+
+    func testFilterConditionsPreserveSelectors() {
+        XCTAssertEqual(
+            HeadlessBrowser.snapshotFilterCondition(for: "inputs"),
+            "node.matches('input, textarea, select, [contenteditable=\"true\"]')")
+        XCTAssertEqual(
+            HeadlessBrowser.snapshotFilterCondition(for: "buttons"),
+            "node.matches('button, input[type=\"button\"], input[type=\"submit\"], [role=\"button\"]')")
+        XCTAssertEqual(
+            HeadlessBrowser.snapshotFilterCondition(for: "links"),
+            "node.matches('a[href]')")
+        XCTAssertEqual(
+            HeadlessBrowser.snapshotFilterCondition(for: "forms"),
+            "node.matches('form, input, textarea, select, button')")
+        XCTAssertEqual(HeadlessBrowser.snapshotFilterCondition(for: "all"), "true")
+        XCTAssertEqual(HeadlessBrowser.snapshotFilterCondition(for: "unknown"), "true")
+    }
+}
+
+final class SnapshotFilterLiveTests: BrowserTestCase {
+
+    override func setUp() {
+        super.setUp()
+        guard context != nil else { return }
+        navigateToFixture("interactive-elements", detail: "none")
+    }
+
+    func testInputsFilterReturnsOnlyInputLikeElements() throws {
+        try skipIfNeeded()
+
+        let snapshot = takeSnapshot(filter: "inputs", detail: "full")
+        let elements = elementLines(in: snapshot)
+
+        XCTAssertFalse(elements.isEmpty, "Inputs filter should return matching elements")
+        XCTAssertTrue(elements.contains("id=\"text-input\""))
+        XCTAssertTrue(elements.contains("id=\"textarea\""))
+        XCTAssertTrue(elements.contains("id=\"select-country\""))
+        XCTAssertTrue(elements.contains("id=\"cb-agree\""))
+        XCTAssertFalse(elements.contains("id=\"btn-primary\""))
+        XCTAssertFalse(elements.contains("id=\"div-button\""))
+        XCTAssertFalse(elements.contains("id=\"link-page1\""))
+    }
+
+    func testButtonsFilterReturnsOnlyButtonElements() throws {
+        try skipIfNeeded()
+
+        let snapshot = takeSnapshot(filter: "buttons", detail: "full")
+        let elements = elementLines(in: snapshot)
+
+        XCTAssertFalse(elements.isEmpty, "Buttons filter should return matching elements")
+        XCTAssertTrue(elements.contains("id=\"btn-primary\""))
+        XCTAssertTrue(elements.contains("id=\"btn-submit\""))
+        XCTAssertTrue(elements.contains("id=\"div-button\""))
+        XCTAssertFalse(elements.contains("id=\"text-input\""))
+        XCTAssertFalse(elements.contains("id=\"select-country\""))
+        XCTAssertFalse(elements.contains("id=\"link-page1\""))
+    }
+
+    func testLinksFilterReturnsOnlyLinks() throws {
+        try skipIfNeeded()
+
+        let snapshot = takeSnapshot(filter: "links", detail: "full")
+        let elements = elementLines(in: snapshot)
+
+        XCTAssertFalse(elements.isEmpty, "Links filter should return matching elements")
+        XCTAssertTrue(elements.contains("id=\"link-page1\""))
+        XCTAssertTrue(elements.contains("id=\"link-page2\""))
+        XCTAssertTrue(elements.contains("id=\"link-external\""))
+        XCTAssertFalse(elements.contains("id=\"text-input\""))
+        XCTAssertFalse(elements.contains("id=\"btn-primary\""))
+        XCTAssertFalse(elements.contains("id=\"select-country\""))
+    }
+
+    func testFormsFilterReturnsFormControlsOnly() throws {
+        try skipIfNeeded()
+
+        let snapshot = takeSnapshot(filter: "forms", detail: "full")
+        let elements = elementLines(in: snapshot)
+
+        XCTAssertFalse(elements.isEmpty, "Forms filter should return matching elements")
+        XCTAssertTrue(elements.contains("id=\"text-input\""))
+        XCTAssertTrue(elements.contains("id=\"textarea\""))
+        XCTAssertTrue(elements.contains("id=\"select-country\""))
+        XCTAssertTrue(elements.contains("id=\"btn-primary\""))
+        XCTAssertFalse(elements.contains("id=\"link-page1\""))
+        XCTAssertFalse(elements.contains("id=\"div-button\""))
+        XCTAssertFalse(elements.contains("id=\"aria-switch\""))
+    }
+
+    func testVisibleOnlyExcludesHiddenFilteredElements() throws {
+        try skipIfNeeded()
+
+        let visibleSnapshot = takeSnapshot(filter: "buttons", visibleOnly: true, detail: "full")
+        let visibleElements = elementLines(in: visibleSnapshot)
+
+        XCTAssertTrue(visibleElements.contains("id=\"btn-primary\""))
+        XCTAssertFalse(visibleElements.contains("id=\"hidden-btn-display\""))
+        XCTAssertFalse(visibleElements.contains("id=\"hidden-btn-visibility\""))
+        XCTAssertFalse(visibleElements.contains("id=\"hidden-btn-opacity\""))
+
+        let allSnapshot = takeSnapshot(filter: "buttons", visibleOnly: false, detail: "full")
+        let allElements = elementLines(in: allSnapshot)
+
+        XCTAssertTrue(allElements.contains("id=\"hidden-btn-display\""))
+        XCTAssertTrue(allElements.contains("id=\"hidden-btn-visibility\""))
+        XCTAssertTrue(allElements.contains("id=\"hidden-btn-opacity\""))
+    }
+
+    private func elementLines(in snapshot: String) -> String {
+        snapshot
+            .split(separator: "\n")
+            .filter { $0.hasPrefix("[E") }
+            .joined(separator: "\n")
+    }
+}


### PR DESCRIPTION
## Summary
Fixes browser snapshot filters so `inputs`, `buttons`, `links`, and `forms` evaluate the `TreeWalker` callback node instead of an out-of-scope loop variable.

The previous JavaScript emitted `el.matches(...)` inside `acceptNode(node)`, which caused filtered snapshots to skip matching elements. This keeps the snapshot output format unchanged and adds regression coverage for both the generated selector expression and live fixture behavior.

## Validation
- `swift test --package-path tools/browser`
- `OSAURUS_BROWSER_TESTS=1 swift test --package-path tools/browser --filter SnapshotFilterLiveTests`
- `swift test --package-path tools/browser --filter SnapshotFilterConditionTests`
- `git diff --check`

## Notes
- Normal `swift test` still skips WebKit-backed tests unless the existing browser test gate is enabled.
- The live WebKit subset was run locally with `OSAURUS_BROWSER_TESTS=1`.
