### PR TITLE
fix(ci): run plugin test gate on the Xcode toolchain

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -61,6 +61,15 @@ jobs:
           VERSION="${VERSION#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      # Test on the runner's default (Xcode) toolchain BEFORE installing the
+      # pinned swift.org toolchain: the swift.org toolchain's test harness
+      # exits with SIGTRAP after the XCTest phase on macOS runners, while
+      # artifact builds below stay on the pinned toolchain. A separate scratch
+      # path keeps the two toolchains from sharing build state.
+      - name: Run tests
+        timeout-minutes: 30
+        run: swift test --scratch-path .build-test
+
       - name: Set up Swift
         uses: swift-actions/setup-swift@v2
         with:
@@ -68,9 +77,6 @@ jobs:
 
       - name: Build release
         run: swift build -c release
-
-      - name: Run tests
-        run: swift test
 
       - name: Find dylib
         id: find


### PR DESCRIPTION
## Summary
- The test gate added to `build-plugin.yml` during the reliability audit ran under the pinned swift.org 6.0 toolchain (installed by `setup-swift`), whose test harness deterministically exits with SIGTRAP after the XCTest phase completes on macOS runners — it failed the calendar 1.1.0 canary release twice with all 27 tests passing.
- Move the `swift test` gate before the `setup-swift` step so it runs on the runner's default Xcode toolchain (the same environment as every plugin's own CI), with an isolated scratch path. Artifact builds are unchanged: still `swift build -c release` on the pinned swift.org toolchain.

## Test plan
- [x] YAML validated locally
- [ ] Calendar 1.1.0 release re-run passes end-to-end against this SHA